### PR TITLE
Ingest metadata from tables

### DIFF
--- a/src/gwasstudio/cli/metadata/ingest.py
+++ b/src/gwasstudio/cli/metadata/ingest.py
@@ -1,32 +1,99 @@
 import json
+from collections import defaultdict
+from typing import Dict, Any, Hashable
 
 import cloup
+import pandas as pd
 
 from gwasstudio import logger
-from gwasstudio.mongo.models import EnhancedDataProfile
+from gwasstudio.mongo.models import EnhancedDataProfile, DataProfile
+from gwasstudio.utils import compute_sha256, lower_and_replace
 
 help_doc = """
 Ingest metadata into a MongoDB collection.
 """
 
 
+def load_data(file_path: str, delimiter: str = "\t") -> pd.DataFrame:
+    """Load data from a file in tabular format."""
+    try:
+        return pd.read_csv(
+            file_path,
+            sep=delimiter,
+            dtype={"project": "category", "study": "category", "file_path": "string[pyarrow]", "category": "category"},
+        )
+    except FileNotFoundError:
+        logger.error("File not found. Please check the file path.")
+        exit(1)
+
+
+def process_row(row: pd.Series) -> Dict[Hashable, Any]:
+    """Process a row of data to create a metadata dictionary."""
+    project_key = lower_and_replace(row["project"])
+    study_key = lower_and_replace(row["study"])
+
+    metadata = defaultdict(lambda: {})
+    metadata["project"] = project_key
+    metadata["study"] = study_key
+    metadata["data_id"] = compute_sha256(fpath=row["file_path"])
+
+    for key, value in row.items():
+        if "_" in key and key.startswith(("platform", "trait", "total")):
+            k, v = key.split("_", 1)
+            metadata[k][v] = value
+        else:
+            if key not in metadata:
+                metadata[key] = value
+
+    return {
+        _key: json.dumps(_value) if _key in DataProfile.json_dictionary_keys() else _value
+        for _key, _value in metadata.items()
+    }
+
+
+def ingest_data(df: pd.DataFrame) -> None:
+    """Ingest data into the MongoDB collection."""
+    documents = [process_row(row) for _, row in df.iterrows()]
+    logger.info(f"{len(documents)} documents to ingest")
+    print(f"{len(documents)} documents to ingest")
+    for document in documents:
+        obj = EnhancedDataProfile(**document)
+        obj.save()
+
+
 @cloup.command("meta_ingest", no_args_is_help=True, help=help_doc)
 @cloup.option_group(
     "Ingestion options",
     cloup.option(
-        "--filepath",
+        "--file_path",
         default=None,
-        help="Path to the file of JSON dictionaries to ingest",
+        help="Path to the file in tabular format to ingest",
+    ),
+    cloup.option(
+        "--delimiter",
+        default="\t",
+        help="Character or regex pattern to treat as the delimiter.",
     ),
 )
-def meta_ingest(filepath):
-    with open(filepath, "r") as fp:
-        jd_list = json.load(fp)
+def meta_ingest(file_path: str, delimiter: str) -> None:
+    """
+    Ingest metadata from a tabular file into a MongoDB collection.
 
-    logger.info("{} documents to ingest".format(len(jd_list)))
-    print("{} documents to ingest".format(len(jd_list)))
+    The function loads the data from the specified file using the provided delimiter,
+    processes each row of data into a metadata dictionary, and then saves these dictionaries
+    as documents in the MongoDB collection.
 
-    for jd in jd_list:
-        logger.debug(jd)
-        obj = EnhancedDataProfile(**jd)
-        obj.save()
+    Args:
+        file_path (str): Path to the file in tabular format to ingest
+        delimiter (str): Character or regex pattern to treat as the delimiter
+
+    Returns:
+        None
+    """
+    df = load_data(file_path, delimiter)
+    required_columns = ["project", "study", "file_path", "category"]
+    if not all(col in df.columns for col in required_columns):
+        raise ValueError(
+            f"Missing column(s) in the input file: {', '.join([col for col in required_columns if col not in df.columns])}"
+        )
+    ingest_data(df)

--- a/src/gwasstudio/cli/metadata/query.py
+++ b/src/gwasstudio/cli/metadata/query.py
@@ -1,28 +1,27 @@
+import csv
 import json
+import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 
 import cloup
 from ruamel.yaml import YAML
 
 from gwasstudio import logger
-from gwasstudio.mongo.models import EnhancedDataProfile
+from gwasstudio.mongo.models import EnhancedDataProfile, DataProfile
+from gwasstudio.utils import lower_and_replace
 
 help_doc = """
 query metadata records from MongoDB
 """
 
 
-def finditem(obj, key):
-    """Search for a specific key in an object, including nested dictionaries.
-    If the given key is found in the object, it returns the corresponding value.
-    If the key is not present, the function recursively searches for the key
-    in its child dictionaries."""
+def find_item(obj: dict, key: str) -> Any:
+    """Recursively search for a specific key in an object."""
     if key in obj:
         return obj[key]
-    for k, v in obj.items():
-        if isinstance(v, dict):
-            return finditem(v, key)
+    else:
+        return next((v for k, v in obj.items() if isinstance(v, dict) and find_item(v, key) is not None), None)
 
 
 def load_search_topics(search_file: str) -> Any | None:
@@ -35,53 +34,87 @@ def load_search_topics(search_file: str) -> Any | None:
     return search_topics
 
 
+def process_search_topics(search_topics: Dict[str, str]) -> Dict[str, str]:
+    """Process search topics by lowercasing and replacing special characters."""
+
+    for key, value in search_topics.items():
+        if key in ("project", "study"):
+            search_topics[key] = lower_and_replace(value)
+
+    return search_topics
+
+
 @cloup.command("meta_query", no_args_is_help=True, help=help_doc)
-@cloup.option("--search-file", required=True, default=None, help="Path to search template")
-def meta_query(search_file):
+@cloup.option("--search-file", required=True, default=None, help="Path to search template file")
+@cloup.option("--output-file", required=True, default=None, help="Path to output file")
+@cloup.option("--stdout", default=False, is_flag=True, help="Do not write to stdout")
+def meta_query(search_file, output_file, stdout):
     """
-    Queries metadata based on given parameters.
+    Queries metadata records from MongoDB based on the search topics specified in the provided template file.
+
+    The search topics are processed by lowercasing and replacing special characters before being used to query the database.
+    The resulting metadata records are then written to the output file or printed to the console if the `--stdout` option is set.
 
     Args:
-        search_file (str): Path to search template
+        search_file (str): Path to the search template YAML file
+        output_file (str): Path to write the query results to
+        stdout (bool): Whether to print the query results to the console instead of writing them to a file
 
     Returns:
         None
     """
 
-    search_topics = load_search_topics(search_file)
+    search_topics = process_search_topics(load_search_topics(search_file))
     logger.debug(search_topics)
 
     obj = EnhancedDataProfile()
     objs = []
 
-    for trait_desc_search_dict in search_topics["trait_desc"]:
-        k, v = next(iter(trait_desc_search_dict.items()))
+    for trait_search_dict in search_topics["trait"]:
+        k, v = next(iter(trait_search_dict.items()))
         # Create a new dictionary with all keys and values, including the current trait
         # Merge dictionaries using the | operator
-        query_dict = search_topics | {"trait_desc": v}
+        query_dict = search_topics | {"trait": v}
+        query_dict.pop("output")
+        logger.debug(query_dict)
         query_result = obj.query(**query_dict)
 
         for qr in query_result:
             if qr not in objs:
                 leaf = k.split(".").pop()
-                json_dict = json.loads(qr["trait_desc"])
-                if v in finditem(json_dict, leaf):
+                json_dict = json.loads(qr["trait"])
+                if v in find_item(json_dict, leaf):
                     objs.append(qr)
 
-    output_fields = search_topics.get("output", ["data_id"])
+    output_fields = ["project", "study", "category", "data_id"] + search_topics.get("output", [])
 
-    for meta_dict in objs:
-        to_print = []
-        for field in output_fields:
-            if field.startswith("trait_desc"):
-                keys = field.split(".")
-                result = meta_dict
-                for key in keys:
-                    if isinstance(result, str):
-                        result = json.loads(result)
-                    result = result.get(key, None)
-                to_print.append(result)
-            else:
-                result = meta_dict.get(field)
-                to_print.append(result)
-        print("\t".join(to_print))
+    with open(output_file, "w") as f:
+        msg = f"{len(objs)} results found. Writing to {output_file}"
+        print(msg)
+        logger.info(msg)
+
+        writer = csv.writer(f, delimiter="\t", lineterminator="\n")
+        if stdout:
+            console_writer = csv.writer(sys.stdout)
+        else:
+            console_writer = None
+
+        # write header
+        writer.writerow(output_fields)
+        if console_writer is not None:
+            console_writer.writerow(output_fields)
+
+        for meta_dict in objs:
+            row = []
+            for field in output_fields:
+                if field.startswith(DataProfile.json_dictionary_keys()):
+                    main_key = field.split(".")[0]
+                    sub_key = field.split(".")[1]
+                    json_dict = json.loads(meta_dict.get(main_key))
+                    row.append(json_dict.get(sub_key, None))
+                else:
+                    row.append(meta_dict.get(field, None))
+            # write each row
+            writer.writerow(row)
+            if console_writer is not None:
+                console_writer.writerow(row)

--- a/src/gwasstudio/data/search_template.yml
+++ b/src/gwasstudio/data/search_template.yml
@@ -1,19 +1,20 @@
-project: DECODE
-study: largescaleplasma2023
-build: GRCh38
-trait_desc:
-      - feature.gene_ids: ENSG00000126456
-      - feature.gene_ids: ENSG00000276885
-      - feature.gene_ids: ENSG00000274406
-      - feature.gene_ids: ENSG00000048545
+project: Decode
+study: large scale plasma 2023
+category: pQTL
+trait:
+  - gene_ids: ENSG00000126456
+  - gene_ids: ENSG00000276885
+  - gene_ids: ENSG00000147124
+  - gene_ids: ENSG00000235307
+  - seq_ids: 10008-43
 
-platform:
-  maker: "Somalogic"
-  version: "v4"
+
 
 output:
-  - trait_desc.feature.protein_ids
-  - trait_desc.feature.gene_ids
-  - trait_desc.feature.seqid
-  - trait_desc.tissue
-  - data_id
+  - trait.protein_ids
+  - trait.gene_ids
+  - trait.seq_ids
+  - trait.tissue
+  - platform.maker
+  - platform.version
+  - total.samples

--- a/src/gwasstudio/data/search_template.yml
+++ b/src/gwasstudio/data/search_template.yml
@@ -2,11 +2,12 @@ project: Decode
 study: large scale plasma 2023
 category: pQTL
 trait:
-  - gene_ids: ENSG00000126456
-  - gene_ids: ENSG00000276885
-  - gene_ids: ENSG00000147124
-  - gene_ids: ENSG00000235307
   - seq_ids: 10008-43
+  - gene_ids: ENSG00000204256
+    seq_ids: 10008-43
+  - gene_ids: ENSG00000147124
+  - seq_ids: 10000-25
+
 
 
 
@@ -15,6 +16,4 @@ output:
   - trait.gene_ids
   - trait.seq_ids
   - trait.tissue
-  - platform.maker
-  - platform.version
   - total.samples

--- a/src/gwasstudio/mongo/mixin.py
+++ b/src/gwasstudio/mongo/mixin.py
@@ -1,6 +1,7 @@
 import datetime
 
 from mongoengine.errors import NotUniqueError
+from mongoengine.queryset.visitor import Q
 
 from gwasstudio import logger
 
@@ -82,8 +83,9 @@ class MongoMixin:
         docs = []
         if len(kwargs) > 0:
             with self.mec:
-                if "trait_desc" in kwargs.keys():
-                    docs = self.klass.objects(trait_desc__contains=kwargs.get("trait_desc")).as_pymongo()
+                if all(item in kwargs.keys() for item in ["trait"]):
+                    trait = kwargs.pop("trait")
+                    docs = self.klass.objects(Q(**kwargs) & Q(trait__contains=trait)).as_pymongo()
                 else:
                     docs = self.klass.objects(**kwargs).as_pymongo()
                 logger.debug("found {} documents".format(len(docs)))

--- a/src/gwasstudio/mongo/models.py
+++ b/src/gwasstudio/mongo/models.py
@@ -5,7 +5,6 @@ from mongoengine import (
     DateTimeField,
     Document,
     EnumField,
-    IntField,
     ListField,
     ReferenceField,
     StringField,
@@ -45,14 +44,18 @@ class DataProfile(Metadata):
     """
 
     project = StringField(max_length=250, required=True)
-    study = StringField(max_length=250, unique_with="project", required=True)
-    data_id = StringField(max_length=250, unique_with="project", required=True)
-    trait_desc = StringField()
-    total_samples = IntField()
-    total_cases = IntField()
+    study = StringField(max_length=250, required=True)
+    data_id = StringField(max_length=250, unique_with=["project", "study"], required=True)
+    trait = StringField()
+    total = StringField()
     population = EnumField(Ancestry)
     references = ListField(ReferenceField(Publication))
     build = EnumField(Build)
+    platform = StringField()
+
+    @staticmethod
+    def json_dictionary_keys() -> tuple:
+        return ("platform", "total", "trait")
 
 
 class EnhancedDataProfile(MongoMixin):
@@ -63,14 +66,14 @@ class EnhancedDataProfile(MongoMixin):
             project=kwargs.get("project"),
             study=kwargs.get("study"),
             data_id=kwargs.get("data_id"),
-            trait_desc=kwargs.get("trait_desc", None),
+            trait=kwargs.get("trait", None),
             category=kwargs.get("category"),
             tags=kwargs.get("tags", []),
-            total_samples=kwargs.get("total_samples"),
-            total_cases=kwargs.get("total_cases"),
+            total=kwargs.get("total", None),
             population=kwargs.get("population", "NR"),
             references=kwargs.get("references", []),
             build=kwargs.get("build", None),
+            platform=kwargs.get("platform", None),
         )
 
     # required attributes

--- a/src/gwasstudio/utils/__init__.py
+++ b/src/gwasstudio/utils/__init__.py
@@ -17,7 +17,7 @@ import tiledb
 DEFAULT_BUFSIZE = 4096
 
 
-def compute_sha256(fpath=None, st=None):
+def compute_sha256(fpath: object = None, st: object = None) -> str:
     """
     Computes file or string hash using sha256 algorithm.
 
@@ -98,6 +98,19 @@ def generate_random_word(length: int) -> str:
         str: A random word of the specified length.
     """
     return "".join(random.choice(string.ascii_lowercase) for _ in range(length))
+
+
+def lower_and_replace(text: str) -> str:
+    """
+    Replaces spaces in the input string with underscores and converts it to lowercase.
+
+    Args:
+        text (str): The input string to be modified.
+
+    Returns:
+        str: The modified string with spaces replaced by underscores and converted to lowercase.
+    """
+    return f"{text.lower().replace(' ', '_')}"
 
 
 # Define the TileDB array schema with SNP, gene, and population dimensions

--- a/tests/unit/test_DataProfile.py
+++ b/tests/unit/test_DataProfile.py
@@ -38,11 +38,10 @@ class TestDataProfile(unittest.TestCase):
             "project": self.cm.get_project_list[0],
             "study": self.study,
             "data_id": self.data_id,
-            "trait_desc": '{"code": "example1", "feature": "example2, "tissue": "example3"}',
+            "trait": '{"code": "example1", "feature": "example2, "tissue": "example3"}',
             "category": "pQTL",
             "tags": ["tag1", "tag2"],
-            "total_samples": 10,
-            "total_cases": 5,
+            "total": '{"samples": "10", "total_cases": "5"}',
             "population": "NR",
             "build": "GRCh38",
         }
@@ -56,10 +55,9 @@ class TestDataProfile(unittest.TestCase):
         self.assertEqual(from_mongo.project, kwargs.get("project"))
         self.assertEqual(from_mongo.study, kwargs.get("study"))
         self.assertEqual(from_mongo.data_id, kwargs.get("data_id"))
-        self.assertEqual(from_mongo.trait_desc, kwargs.get("trait_desc"))
+        self.assertEqual(from_mongo.trait, kwargs.get("trait"))
         self.assertEqual(from_mongo.category.value, kwargs.get("category"))
         self.assertEqual(from_mongo.tags, kwargs.get("tags"))
-        self.assertEqual(from_mongo.total_samples, kwargs.get("total_samples"))
-        self.assertEqual(from_mongo.total_cases, kwargs.get("total_cases"))
+        self.assertEqual(from_mongo.total, kwargs.get("total"))
         self.assertEqual(from_mongo.population.value, kwargs.get("population"))
         self.assertEqual(from_mongo.build.value, kwargs.get("build"))

--- a/tests/unit/test_DataProfile.py
+++ b/tests/unit/test_DataProfile.py
@@ -1,10 +1,11 @@
 import unittest
 
 import mongomock
+from mongoengine import connect, disconnect, get_connection
+
 from gwasstudio.config_manager import ConfigurationManager
 from gwasstudio.mongo.models import EnhancedDataProfile, DataProfile
 from gwasstudio.utils import compute_sha256, generate_random_word
-from mongoengine import connect, disconnect, get_connection
 
 
 class TestDataProfile(unittest.TestCase):
@@ -13,6 +14,7 @@ class TestDataProfile(unittest.TestCase):
         self.cm = ConfigurationManager()
 
         self.data_id = compute_sha256(st=generate_random_word(64))
+        self.study = generate_random_word(250)
 
     def tearDown(self) -> None:
         if DataProfile.objects().first():
@@ -34,6 +36,7 @@ class TestDataProfile(unittest.TestCase):
     def test_DataProfile_fields(self):
         kwargs = {
             "project": self.cm.get_project_list[0],
+            "study": self.study,
             "data_id": self.data_id,
             "trait_desc": '{"code": "example1", "feature": "example2, "tissue": "example3"}',
             "category": "pQTL",
@@ -47,8 +50,11 @@ class TestDataProfile(unittest.TestCase):
         obj = EnhancedDataProfile(mec=self.mec, **kwargs)
         obj.save()
 
-        from_mongo = DataProfile.objects(project=kwargs.get("project"), data_id=kwargs.get("data_id")).first()
+        from_mongo = DataProfile.objects(
+            project=kwargs.get("project"), study=kwargs.get("study"), data_id=kwargs.get("data_id")
+        ).first()
         self.assertEqual(from_mongo.project, kwargs.get("project"))
+        self.assertEqual(from_mongo.study, kwargs.get("study"))
         self.assertEqual(from_mongo.data_id, kwargs.get("data_id"))
         self.assertEqual(from_mongo.trait_desc, kwargs.get("trait_desc"))
         self.assertEqual(from_mongo.category.value, kwargs.get("category"))

--- a/tests/unit/test_EnhancedDataProfile.py
+++ b/tests/unit/test_EnhancedDataProfile.py
@@ -1,10 +1,11 @@
 import unittest
 
 import mongomock
+from mongoengine import connect, disconnect, get_connection
+
 from gwasstudio.config_manager import ConfigurationManager
 from gwasstudio.mongo.models import EnhancedDataProfile, DataProfile
 from gwasstudio.utils import generate_random_word, compute_sha256
-from mongoengine import connect, disconnect, get_connection
 
 
 class TestEnhancedDataProfile(unittest.TestCase):
@@ -13,6 +14,7 @@ class TestEnhancedDataProfile(unittest.TestCase):
         self.cm = ConfigurationManager()
 
         self.data_id = compute_sha256(st=generate_random_word(64))
+        self.study = generate_random_word(250)
 
     def tearDown(self) -> None:
         if DataProfile.objects().first():
@@ -43,16 +45,18 @@ class TestEnhancedDataProfile(unittest.TestCase):
         If obj is mapped, then obj.pk is not None
         """
         project = self.cm.get_project_list[0]
+        study = self.study
         data_id = self.data_id
-        obj = EnhancedDataProfile(project=project, data_id=data_id, mec=self.mec)
+        obj = EnhancedDataProfile(project=project, study=study, data_id=data_id, mec=self.mec)
         obj.save()
         assert obj.pk is not None
 
     def test_unique_key(self):
         project = self.cm.get_project_list[0]
+        study = self.study
         data_id = self.data_id
-        obj = EnhancedDataProfile(project=project, data_id=data_id, mec=self.mec)
-        self.assertEqual(obj.unique_key, f"{obj.mdb_obj.project}:{obj.mdb_obj.data_id}")
+        obj = EnhancedDataProfile(project=project, study=study, data_id=data_id, mec=self.mec)
+        self.assertEqual(obj.unique_key, f"{obj.mdb_obj.project}:{obj.mdb_obj.study}:{obj.mdb_obj.data_id}")
 
     def test_is_connected(self):
         """

--- a/tests/unit/test_metadata_query.py
+++ b/tests/unit/test_metadata_query.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from gwasstudio.cli.metadata.query import load_search_topics, finditem, YAML
+
+
+class TestLoadSearchTopics(unittest.TestCase):
+    def setUp(self):
+        self.yml = YAML(typ="safe")
+        self.test_file = Path("tests/test_metadata.yaml")
+        self.test_data = {"trait_desc": [{"a": "1"}, {"b": "2"}]}
+        self.yml.dump(self.test_data, self.test_file)
+
+    def tearDown(self):
+        if self.test_file.exists():
+            self.test_file.unlink()
+
+    @patch("pathlib.Path.exists", new_callable=MagicMock)
+    def test_loads_search_topics(self, mock_exists):
+        mock_exists.return_value = True
+        result = load_search_topics(str(self.test_file))
+        self.assertIsInstance(result, dict)
+        self.assertDictEqual(self.test_data, result)
+        # mock_exists.assert_called_once_with(str(self.test_file))
+
+    @patch("pathlib.Path.exists", new_callable=MagicMock)
+    def test_returns_none_if_file_doesnt_exist(self, mock_exists):
+        mock_exists.return_value = False
+        result = load_search_topics(str(self.test_file.name))
+        self.assertIsNone(result)
+        # mock_exists.assert_called_once_with(str(self.test_file))
+
+
+class TestFindItem(unittest.TestCase):
+    def test_finditem(self):
+        data = {"a": {"b": 1, "c": {"d": 2}}}
+        assert finditem(data, "a") == data["a"]
+        assert finditem(data["a"], "c") == data["a"]["c"]
+        assert finditem(data["a"]["c"], "d") == 2
+        assert finditem(data, "e") is None

--- a/tests/unit/test_metadata_query.py
+++ b/tests/unit/test_metadata_query.py
@@ -2,7 +2,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from gwasstudio.cli.metadata.query import load_search_topics, finditem, YAML
+from gwasstudio.cli.metadata.query import load_search_topics, find_item, YAML
 
 
 class TestLoadSearchTopics(unittest.TestCase):
@@ -33,9 +33,9 @@ class TestLoadSearchTopics(unittest.TestCase):
 
 
 class TestFindItem(unittest.TestCase):
-    def test_finditem(self):
+    def test_find_item(self):
         data = {"a": {"b": 1, "c": {"d": 2}}}
-        assert finditem(data, "a") == data["a"]
-        assert finditem(data["a"], "c") == data["a"]["c"]
-        assert finditem(data["a"]["c"], "d") == 2
-        assert finditem(data, "e") is None
+        assert find_item(data, "a") == data["a"]
+        assert find_item(data["a"], "c") == data["a"]["c"]
+        assert find_item(data["a"]["c"], "d") == 2
+        assert find_item(data, "e") is None

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -14,9 +14,8 @@ class TestEnhancedDataProfileQuery(unittest.TestCase):
             project="project1",
             study="study1",
             data_id="data_id1",
-            trait_desc="trait_desc1",
-            total_samples=10,
-            total_cases=5,
+            trait="trait_desc1",
+            total='{"samples": "10"}',
             population=Ancestry.EUROPEAN,
             references=[],
             build=Build.GRCH37,
@@ -27,9 +26,8 @@ class TestEnhancedDataProfileQuery(unittest.TestCase):
             project="project2",
             study="study2",
             data_id="data_id2",
-            trait_desc="trait_desc2",
-            total_samples=20,
-            total_cases=10,
+            trait="trait_desc2",
+            total='{"samples": "20"}',
             population=Ancestry.ICELANDIC,
             references=[],
             build=Build.GRCH38,
@@ -40,9 +38,8 @@ class TestEnhancedDataProfileQuery(unittest.TestCase):
             project="project2",
             study="study3",
             data_id="data_id3",
-            trait_desc="trait_desc1",
-            total_samples=30,
-            total_cases=15,
+            trait="trait_desc1",
+            total='{"samples": "30"}',
             population=Ancestry.EUROPEAN,
             references=[],
             build=Build.GRCH37,
@@ -68,7 +65,7 @@ class TestEnhancedDataProfileQuery(unittest.TestCase):
         disconnect()
 
     def test_query_by_trait_desc(self):
-        profiles = EnhancedDataProfile(mec=self.mec).query(trait_desc="trait_desc1")
+        profiles = EnhancedDataProfile(mec=self.mec).query(trait="trait_desc1")
         assert len(profiles) == 2
         self.assertIn(self.profile1.view(), profiles)
         self.assertIn(self.profile3.view(), profiles)

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -12,6 +12,7 @@ class TestEnhancedDataProfileQuery(unittest.TestCase):
         self.profile1 = EnhancedDataProfile(
             mec=self.mec,
             project="project1",
+            study="study1",
             data_id="data_id1",
             trait_desc="trait_desc1",
             total_samples=10,
@@ -23,7 +24,8 @@ class TestEnhancedDataProfileQuery(unittest.TestCase):
         self.profile1.save()
         self.profile2 = EnhancedDataProfile(
             mec=self.mec,
-            project="project1",
+            project="project2",
+            study="study2",
             data_id="data_id2",
             trait_desc="trait_desc2",
             total_samples=20,
@@ -36,7 +38,8 @@ class TestEnhancedDataProfileQuery(unittest.TestCase):
         self.profile3 = EnhancedDataProfile(
             mec=self.mec,
             project="project2",
-            data_id="data_id1",
+            study="study3",
+            data_id="data_id3",
             trait_desc="trait_desc1",
             total_samples=30,
             total_cases=15,


### PR DESCRIPTION
* Models, study is now part of the unique-key
* Meta-ingestion use a tabular file as input. There is only one input table file, columns can be added as needed; only project, study, category and file_path are required. trait_* can be used to store trait values
* Meta-query can handle trait dictionary with more than one element
