### PR TITLE
provide an embedded mongodb setup, fix #46

### DIFF
--- a/base_environment.yml
+++ b/base_environment.yml
@@ -8,3 +8,4 @@ dependencies:
   - pip  # pip must be mentioned explicitly, or conda-lock will fail
   - poetry=2.*
   - make
+  - mongodb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "appdirs (>=1.4.4,<2.0.0)",
     "click (>=8.1.8,<9.0.0)",
     "tiledb (>=0.33.2,<0.34.0)",
     "cloup (>=3.0.5,<4.0.0)",
@@ -25,6 +24,7 @@ dependencies = [
     "botocore (>=1.37.11,<2.0.0)",
     "ruamel-yaml (>=0.18.10,<0.19.0)",
     "hvac (>=2.3.0,<3.0.0)",
+    "platformdirs (>=4.3.8,<5.0.0)",
 ]
 
 [project.scripts]

--- a/src/gwasstudio/__init__.py
+++ b/src/gwasstudio/__init__.py
@@ -1,8 +1,9 @@
 import importlib.metadata
+from pathlib import Path
 
-from appdirs import user_config_dir, user_log_dir
 from cloup import Context, HelpFormatter, HelpTheme, Style
 from loguru import logger as a_logger
+from platformdirs import user_config_dir, user_data_dir, user_log_dir
 
 __all__ = [
     "__appname__",
@@ -10,16 +11,30 @@ __all__ = [
     "context_settings",
     "config_dir",
     "config_filename",
+    "data_dir",
     "log_file",
     "logger",
+    "mongo_db_path",
+    "mongo_db_logpath",
 ]
 
 __appname__ = __name__
 __version__ = importlib.metadata.version(__appname__)
-log_file = user_log_dir(__appname__)
 
-config_dir = user_config_dir(__appname__)
+log_dir = Path(user_log_dir(__appname__))
+log_dir.mkdir(parents=True, exist_ok=True)
+log_file = log_dir / "gwasstudio.log"
+
+config_dir = Path(user_config_dir(__appname__))
+config_dir.mkdir(parents=True, exist_ok=True)
 config_filename = "config.yaml"
+
+data_dir = Path(user_data_dir(__appname__)) / "data"
+data_dir.mkdir(parents=True, exist_ok=True)
+
+mongo_db_path = data_dir / "mongo_db"
+mongo_db_path.mkdir(parents=True, exist_ok=True)
+mongo_db_logpath = log_dir / "mongod.log"
 
 # Check the docs for all available arguments of HelpFormatter and HelpTheme.
 formatter_settings = HelpFormatter.settings(

--- a/src/gwasstudio/cli/info.py
+++ b/src/gwasstudio/cli/info.py
@@ -1,6 +1,6 @@
 import cloup
 
-from gwasstudio import __appname__, __version__, config_dir, log_file
+from gwasstudio import __appname__, __version__, config_dir, data_dir, log_dir
 
 help_doc = """
 Show GWASStudio details
@@ -11,7 +11,7 @@ Show GWASStudio details
 def info():
     print("{}, version {}\n".format(__appname__.capitalize(), __version__))
 
-    paths = {"config dir": config_dir, "log file": log_file}
+    paths = {"config dir": config_dir, "data dir": data_dir, "log dir": log_dir}
     print("Paths: ")
     for k, v in paths.items():
         print("  {}: {}".format(k, v))

--- a/src/gwasstudio/cli/metadata/ingest.py
+++ b/src/gwasstudio/cli/metadata/ingest.py
@@ -5,6 +5,7 @@ import cloup
 
 from gwasstudio.utils.cfg import get_mongo_uri
 from gwasstudio.utils.metadata import load_metadata, ingest_metadata
+from gwasstudio.utils.mongo_manager import manage_mongo
 
 help_doc = """
 Ingest metadata into a MongoDB collection.
@@ -48,6 +49,6 @@ def meta_ingest(ctx, file_path: str, delimiter: str) -> None:
     if missing_cols:
         raise ValueError(f"Missing column(s) in the input file: {', '.join(missing_cols)}")
 
-    mongo_uri = get_mongo_uri(ctx)
-
-    ingest_metadata(df, mongo_uri)
+    with manage_mongo(ctx):
+        mongo_uri = get_mongo_uri(ctx)
+        ingest_metadata(df, mongo_uri)

--- a/src/gwasstudio/cli/metadata/query.py
+++ b/src/gwasstudio/cli/metadata/query.py
@@ -12,6 +12,7 @@ from gwasstudio.utils.metadata import (
     query_mongo_obj,
     dataframe_from_mongo_objs,
 )
+from gwasstudio.utils.mongo_manager import manage_mongo
 
 help_doc = """
 query metadata records from MongoDB
@@ -46,10 +47,10 @@ def meta_query(ctx, search_file, output_prefix, case_sensitive):
     search_topics, output_fields = load_search_topics(search_file)
     logger.debug(search_topics)
 
-    mongo_uri = get_mongo_uri(ctx)
-
-    obj = EnhancedDataProfile(uri=mongo_uri)
-    objs = query_mongo_obj(search_topics, obj, case_sensitive=case_sensitive)
+    with manage_mongo(ctx):
+        mongo_uri = get_mongo_uri(ctx)
+        obj = EnhancedDataProfile(uri=mongo_uri)
+        objs = query_mongo_obj(search_topics, obj, case_sensitive=case_sensitive)
 
     # write metadata query result
     path = Path(output_prefix)

--- a/src/gwasstudio/config/config.yaml
+++ b/src/gwasstudio/config/config.yaml
@@ -1,7 +1,7 @@
 # MongoDB connection
 mdbc:
   # local
-  uri: "mongodb://localhost:27017/tiledb"
+  uri: "mongodb://localhost:27017/cdh"
   # remote
 #  uri: "mongodb://username:password@hostname:27017/dbname?authSource=dbname"
 

--- a/src/gwasstudio/main.py
+++ b/src/gwasstudio/main.py
@@ -11,6 +11,7 @@ from gwasstudio.cli.metadata.ingest import meta_ingest
 from gwasstudio.cli.metadata.query import meta_query
 from gwasstudio.cli.metadata.view import meta_view
 from gwasstudio.dask_client import DaskCluster as Cluster, dask_deployment_types
+from gwasstudio.utils.mongo_manager import mongo_deployment_types
 
 
 def configure_logging(stdout, verbosity, _logger):
@@ -57,12 +58,18 @@ def configure_logging(stdout, verbosity, _logger):
 @cloup.option("--verbosity", type=click.Choice(["quiet", "normal", "loud"]), default="normal", help="Set log verbosity")
 @cloup.option("--stdout", is_flag=True, default=False, help="Print logs to the stdout")
 @cloup.option_group(
-    "Dask deployment options",
+    "Deployment options",
     cloup.option(
         "--dask-deployment",
         type=click.Choice(["local", "gateway", "slurm", "none"]),
         default="none",
-        help="Where the dask cluster will be deployed.",
+        help="The deployment location for the Dask cluster",
+    ),
+    cloup.option(
+        "--mongo-deployment",
+        type=click.Choice(mongo_deployment_types),
+        default="embedded",
+        help="The deployment location for the MongoDB server",
     ),
 )
 @cloup.option_group(
@@ -76,7 +83,7 @@ def configure_logging(stdout, verbosity, _logger):
 )
 @cloup.option_group(
     "Dask local cluster options",
-    cloup.option("--local-workers", default=4, help="Number of workers for local cluster"),
+    cloup.option("--local-workers", default=2, help="Number of workers for local cluster"),
     cloup.option("--local-threads", default=2, help="Threads per worker for local cluster"),
     cloup.option("--local-memory", default="4GB", help="Memory per worker for local cluster"),
 )
@@ -129,6 +136,7 @@ def cli_init(
     cpu_workers,
     address,
     mongo_uri,
+    mongo_deployment,
     verbosity,
     stdout,
     vault_auth,
@@ -141,7 +149,7 @@ def cli_init(
     logger.info("{} started".format(__appname__.capitalize()))
 
     ctx.ensure_object(dict)
-    ctx.obj["mongo"] = {"uri": mongo_uri}
+    ctx.obj["mongo"] = {"uri": mongo_uri, "deployment": mongo_deployment}
 
     ctx.obj["vault"] = {
         "auth": vault_auth,

--- a/src/gwasstudio/utils/cfg.py
+++ b/src/gwasstudio/utils/cfg.py
@@ -3,6 +3,12 @@ from typing import Dict
 from gwasstudio.utils.vault import get_config_from_vault
 
 
+def get_mongo_deployment(ctx: object) -> str:
+    """Retrieve MongoDB deployment from command line options."""
+    mongo_deployment = ctx.obj.get("mongo").get("deployment")
+    return mongo_deployment
+
+
 def get_mongo_uri(ctx: object) -> str:
     """Retrieve MongoDB URI from Vault or command line options."""
 

--- a/src/gwasstudio/utils/mongo_manager.py
+++ b/src/gwasstudio/utils/mongo_manager.py
@@ -1,0 +1,81 @@
+import subprocess
+import time
+from contextlib import contextmanager
+
+from gwasstudio import logger, mongo_db_path, mongo_db_logpath
+from gwasstudio.utils.cfg import get_mongo_deployment, get_mongo_uri
+
+mongo_deployment_types = ["embedded", "standalone"]
+
+
+@contextmanager
+def manage_mongo(ctx):
+    embedded_mongo = (get_mongo_deployment(ctx) == "embedded") and (get_mongo_uri(ctx) is None)
+    logger.debug(f"Embedded MongoDB: {embedded_mongo}")
+    mdb = MongoDBManager()
+    if embedded_mongo:
+        mdb.start()
+    try:
+        yield
+    except Exception as e:
+        logger.error(f"Error occurred: {e}")
+        raise
+    finally:
+        if embedded_mongo:
+            mdb.stop()
+
+
+class MongoDBManager:
+    def __init__(self, dbpath=mongo_db_path, logpath=mongo_db_logpath):
+        self.dbpath = dbpath
+        self.process = None
+        self.logpath = logpath
+
+    def start(self):
+        try:
+            # Start the MongoDB server
+            self.process = subprocess.Popen(
+                ["mongod", "--dbpath", self.dbpath, "--logpath", self.logpath, "--logappend"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            logger.debug("Attempting to start embedded MongoDB server...")
+
+            # Check if the server is running
+            while True:
+                return_code = self.process.poll()
+                if return_code is not None:
+                    logger.error("MongoDB server stopped unexpectedly.")
+                    break
+
+                # Check if the server is ready to accept connections
+                try:
+                    # Attempt to connect to the MongoDB server
+                    subprocess.run(
+                        ["mongosh", "--eval", "db.runCommand({ping: 1})"],
+                        check=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                    )
+                    logger.info("MongoDB server is running and ready to accept connections.")
+                    break
+                except subprocess.CalledProcessError:
+                    # Server is not ready yet, wait and try again
+                    time.sleep(1)
+
+        except Exception as e:
+            logger.error(f"Failed to start MongoDB server: {e}")
+
+    def stop(self):
+        try:
+            # Stop the MongoDB server
+            self.process.terminate()
+            self.process.wait()
+            self.process = None
+            logger.info("MongoDB server stopped.")
+        except Exception as e:
+            logger.error(f"Failed to stop MongoDB server: {e}")
+
+    def __del__(self):
+        if self.process and self.process.poll() is None:
+            self.stop()

--- a/tests/unit/test_mongo_manager.py
+++ b/tests/unit/test_mongo_manager.py
@@ -1,0 +1,81 @@
+import subprocess
+import unittest
+from unittest.mock import patch, MagicMock
+
+from gwasstudio.utils.mongo_manager import MongoDBManager
+
+
+class TestMongoDBManager(unittest.TestCase):
+    @patch("gwasstudio.utils.mongo_manager.subprocess.Popen")
+    @patch("gwasstudio.utils.mongo_manager.subprocess.run")
+    @patch("gwasstudio.utils.mongo_manager.logger")
+    def test_start(self, mock_logger, mock_subprocess_run, mock_subprocess_popen):
+        # Mock the Popen and run methods
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_subprocess_popen.return_value = mock_process
+        mock_subprocess_run.return_value = MagicMock()
+
+        # Create an instance of MongoDBManager
+        manager = MongoDBManager(dbpath="/tmp/mongo_test", logpath="/tmp/mongo_test.log")
+
+        # Start the MongoDB server
+        manager.start()
+
+        # Assert that the Popen method was called with the correct arguments
+        mock_subprocess_popen.assert_called_once_with(
+            ["mongod", "--dbpath", "/tmp/mongo_test", "--logpath", "/tmp/mongo_test.log", "--logappend"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        # Assert that the logger was called to indicate the server is running
+        mock_logger.info.assert_called_with("MongoDB server is running and ready to accept connections.")
+
+    @patch("gwasstudio.utils.mongo_manager.subprocess.Popen")
+    @patch("gwasstudio.utils.mongo_manager.logger")
+    def test_stop(self, mock_logger, mock_subprocess_popen):
+        # Mock the Popen method
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_subprocess_popen.return_value = mock_process
+
+        # Create an instance of MongoDBManager
+        manager = MongoDBManager(dbpath="/tmp/mongo_test")
+
+        # Start the MongoDB server
+        manager.start()
+
+        # Stop the MongoDB server
+        manager.stop()
+
+        # Assert that the terminate and wait methods were called
+        mock_process.terminate.assert_called_once()
+        mock_process.wait.assert_called_once()
+
+        # Assert that the logger was called to indicate the server is stopped
+        mock_logger.info.assert_called_with("MongoDB server stopped.")
+
+    @patch("gwasstudio.utils.mongo_manager.subprocess.Popen")
+    @patch("gwasstudio.utils.mongo_manager.logger")
+    def test_del(self, mock_logger, mock_subprocess_popen):
+        # Mock the Popen method
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_subprocess_popen.return_value = mock_process
+
+        # Create an instance of MongoDBManager
+        manager = MongoDBManager(dbpath="/tmp/mongo_test")
+
+        # Start the MongoDB server
+        manager.start()
+
+        # Explicitly call the __del__ method
+        manager.__del__()
+
+        # Assert that the terminate and wait methods were called
+        mock_process.terminate.assert_called_once()
+        mock_process.wait.assert_called_once()
+
+        # Assert that the logger was called to indicate the server is stopped
+        mock_logger.info.assert_called_with("MongoDB server stopped.")


### PR DESCRIPTION
Add an option for using an embedded MongoDB. It should be the default deployment choice if a standalone deployment is not set in the CLI arguments.
If the CLI argument provides a MongoDB uri, the embedded db is disabled by default.
If MongoDB settings are provided through the Vault dictionaries, then the standalone option must be set explicitly for the MongoDB deployment.