### PR TITLE
Implement TileDB SM configuration retrieving from the configuration file

### DIFF
--- a/src/gwasstudio/cli/ingest.py
+++ b/src/gwasstudio/cli/ingest.py
@@ -7,7 +7,13 @@ from dask import delayed, compute
 from gwasstudio import logger
 from gwasstudio.dask_client import dask_deployment_types, manage_daskcluster
 from gwasstudio.utils import create_tiledb_schema, parse_uri, process_and_ingest, check_file_exists
-from gwasstudio.utils.cfg import get_tiledb_config, get_dask_batch_size, get_dask_deployment, get_mongo_uri
+from gwasstudio.utils.cfg import (
+    get_tiledb_config,
+    get_tiledb_sm_config,
+    get_dask_batch_size,
+    get_dask_deployment,
+    get_mongo_uri,
+)
 from gwasstudio.utils.metadata import load_metadata, ingest_metadata
 from gwasstudio.utils.mongo_manager import manage_mongo
 from gwasstudio.utils.s3 import does_uri_path_exist
@@ -159,6 +165,7 @@ def ingest_to_fs(ctx, input_file_list, uri, pvalue):
         uri (str): Destination path where to store the tiledb dataset in the local file system.
         pvalue (bool): Indicate whether to ingest the p-value from the summary statistics instead of calculating it.
     """
+    cfg = get_tiledb_sm_config()
     _, __, path = parse_uri(uri)
     if not Path(path).exists():
         logger.info("Creating TileDB schema")
@@ -176,7 +183,7 @@ def ingest_to_fs(ctx, input_file_list, uri, pvalue):
                 logger.warning(f"Skipping files: {skipped_files}")
             # Create a list of delayed tasks
             tasks = [
-                delayed(process_and_ingest)(file_path, uri, {}, pvalue)
+                delayed(process_and_ingest)(file_path, uri, cfg, pvalue)
                 for file_path in batch_files
                 if batch_files[file_path]
             ]

--- a/src/gwasstudio/config/config.yaml
+++ b/src/gwasstudio/config/config.yaml
@@ -44,3 +44,8 @@ data_category:
 hashing:
   algorithm: "sha256"
   length: 10
+
+# TileDB configuration
+# https://cloud.tiledb.com/academy/structure/arrays/tutorials/basics/configuration/index.html
+tiledb_sm_config:
+  "sm.dedup_coords": 'true'

--- a/src/gwasstudio/config_manager.py
+++ b/src/gwasstudio/config_manager.py
@@ -64,6 +64,8 @@ class ConfigurationManager(metaclass=SingletonConfigurationManager):
         self._hash_algorithm = c.get("hashing", {"algorithm": "sha256"}).get("algorithm")
         self._hash_length = c.get("hashing", {"length": 10}).get("length")
 
+        self._tiledb_sm_config = c.get("tiledb_sm_config", {})
+
     @property
     def get_mdbc_db(self):
         return self.mdbc_db
@@ -91,3 +93,7 @@ class ConfigurationManager(metaclass=SingletonConfigurationManager):
     @property
     def hash_length(self):
         return self._hash_length
+
+    @property
+    def tiledb_sm_config(self):
+        return self._tiledb_sm_config

--- a/src/gwasstudio/main.py
+++ b/src/gwasstudio/main.py
@@ -164,7 +164,6 @@ def cli_init(
         "vfs.s3.scheme": aws_scheme,
         "vfs.s3.region": aws_region,
         "vfs.s3.verify_ssl": aws_verify_ssl,
-        "sm.dedup_coords": "true",
     }
 
     batch_sizes = {"gateway": minimum_workers, "slurm": maximum_workers * 3, "local": local_workers}

--- a/src/gwasstudio/utils/__init__.py
+++ b/src/gwasstudio/utils/__init__.py
@@ -224,7 +224,8 @@ def process_and_ingest(file_path: str, uri: str, cfg: dict, ingest_pval: bool) -
     hg = Hashing()
     df["TRAITID"] = hg.compute_hash(fpath=file_path)
     # Store the processed data in TileDB
-    ctx = tiledb.Ctx(cfg)
+    print(cfg)
+    ctx = tiledb.Ctx(tiledb.Config(cfg))
     tiledb.from_pandas(
         uri=uri,
         dataframe=df,


### PR DESCRIPTION
   This PR adds support for using the TileDB SM configuration when ingesting datasets f. The change includes retrieving the SM configuration from the configuration file and passing it to the `process_and_ingest` function. Additionally, minor adjustments were made to import statements to reflect this new functionality.
   
   
   Should fix issue #41 
