### PR TITLE
Refactor compute_hash function to improve flexibility

### DIFF
--- a/src/gwasstudio/utils/hashing.py
+++ b/src/gwasstudio/utils/hashing.py
@@ -25,9 +25,13 @@ class Hashing:
     def hash_length(self):
         return self.length
 
-    def compute_hash(self, fpath: object = None, st: object = None) -> str | None:
+    def compute_hash(self, fpath: str = None, st: str = None) -> str | None:
         """
-        Computes file or string hash using the specified algorithm.
+        Computes file or string hash using the algorithm set in the class.
+        Notes:
+            - If `fpath` is provided, the hash is computed based on the filename and file content.
+            - If `st` is provided, the hash is computed based on the string content.
+            - If neither `fpath` nor `st` is provided, the function returns None.
 
         Args:
             fpath (str): Path to a file for which to compute the hash.
@@ -41,7 +45,14 @@ class Hashing:
             case (None, _):
                 hash_value = self.compute_string_hash(st)
             case (_, None):
-                hash_value = self.compute_file_hash(pathlib.Path(fpath))
+                # Convert the file path to a Path object
+                path = pathlib.Path(fpath)
+                # Compute the hash of the filename
+                filename_hash = self.compute_string_hash(path.name)
+                # Compute the hash of the file content
+                file_content_hash = self.compute_file_hash(path)
+                # Bind the filename hash, and the file content hash
+                hash_value = self.compute_string_hash(filename_hash + file_content_hash)
             case _:
                 raise ValueError("Cannot provide both file path and string")
 
@@ -79,71 +90,3 @@ class Hashing:
         h = hashlib.new(self.algorithm)
         h.update(st.encode("ascii"))
         return h.hexdigest()
-
-
-# def compute_hash(fpath: object = None, st: object = None, length: int | None = None) -> str | None:
-#     hash_value = compute_sha256(fpath, st)
-#     return hash_value if length is None else hash_value[:length] if hash_value else None
-#
-#
-# def compute_sha256(fpath: object = None, st: object = None) -> str | None:
-#     """
-#     Computes file or string hash using sha256 algorithm.
-#
-#     Args:
-#         fpath (str): Path to a file for which to compute the hash.
-#         st (str): String for which to compute the hash.
-#     Returns:
-#         str: The SHA-256 hash of the input as a hexadecimal string, or None if neither input is provided.
-#     """
-#     algorithm = "sha256"
-#
-#     match (fpath, st):
-#         case (None, None):
-#             return None
-#         case (None, _):
-#             return compute_string_hash(algorithm, st)
-#         case (_, None):
-#             return compute_file_hash(algorithm, pathlib.Path(fpath))
-#         case _:
-#             raise ValueError("Cannot provide both file path and string")
-
-
-# def compute_file_hash(algorithm: str, path: pathlib.Path, bufsize: int = DEFAULT_BUFSIZE) -> str:
-#     """
-#     Computes the hash of a file using the algorithm function
-#
-#     Args:
-#         algorithm (str): The name of the hashing algorithm.
-#         path: The path to the file for which to compute the hash.
-#         bufsize (int): The size of the buffer to use when reading the file.
-#
-#     Returns:
-#         str: The hexadecimal representation of the SHA-256 hash.
-#
-#     """
-#     # with open(path, "rb") as fp:
-#     #   return hashlib.file_digest(fp, algorithm).hexdigest()
-#     digest = hashlib.new(algorithm)
-#     with open(path, "rb") as fp:
-#         s = fp.read(bufsize)
-#         while s:
-#             digest.update(s)
-#             s = fp.read(bufsize)
-#     return digest.hexdigest()
-
-
-# def compute_string_hash(algorithm: str, st: str) -> str:
-#     """
-#     Computes the hash of a string using the algorithm function.
-#
-#     Args:
-#         algorithm (str): The name of the hashing algorithm.
-#         st: The string for which to compute the hash.
-#
-#     Returns:
-#         str: The hexadecimal representation of the SHA-256 hash.
-#     """
-#     h = hashlib.new(algorithm)
-#     h.update(st.encode("ascii"))
-#     return h.hexdigest()


### PR DESCRIPTION
   If a file path is provided, the function calculates the hash value using both the file name and its contents. The hash length remains the same.
   Previous behaviour: The function only accepted a file path as input and returned the SHA-256 hash based on that file's content.


   This refactoring fixes #64