### PR TITLE
feat: Update Mongo query composition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,28 @@ functional_test_02:
 test: unit_test functional_test_00
 	@echo "End-to-End tests"
 
+test-integration: test-integration-setup test-integration-exec #test-integration-stop## Run integration tests
+
+test-integration-setup: ## Start Docker services for integration tests
+	docker compose -f dev/docker-compose-integration.yml up -d
+	sleep 5
+
+test-integration-exec: ## Run integration tests (excluding provision)
+	@echo "Integration test 03"
+	@if [ -z "${CONDA_DEFAULT_ENV}" ] || [ "${CONDA_DEFAULT_ENV}" != "${ENV_NAME}" ]; then \
+        echo "Activating conda environment: ${ENV_NAME}"; \
+		$(CONDA_ACTIVATE) ${ENV_NAME}; \
+	fi; \
+	cd scripts && ./test_03.sh
+
+test-integration-stop:
+	docker compose -f dev/docker-compose-integration.yml rm -f -s -v minio
+	docker compose -f dev/docker-compose-integration.yml rm -f -s -v mongodb
+	docker compose -f dev/docker-compose-integration.yml rm -f -s -v vault
+	docker compose -f dev/docker-compose-integration.yml rm -f -s -v vault-init
+	docker network rm -f internal_net
+	docker volume rm dev_minio_data dev_mongodb_data dev_vault_data
+
 
 
 uninstall:

--- a/data/metadata_table.tsv
+++ b/data/metadata_table.tsv
@@ -3,7 +3,6 @@ opengwas	bbj-a	GWAS	./dataset/bbj-a-1.gwaslab.tsv.sampled.gz		Combined	bbj-a-1	G
 opengwas	bbj-a	GWAS	./dataset/bbj-a-2.gwaslab.tsv.sampled.gz		Males	bbj-a-2	GRCh37	East Asian	85894			Body mass index
 opengwas	bbj-a	GWAS	./dataset/bbj-a-3.gwaslab.tsv.sampled.gz		Females	bbj-a-3	GRCh37	East Asian	72390			Body mass index
 opengwas	ebi-a	GWAS	./dataset/ebi-a-GCST004904.gwaslab.tsv.sampled.gz			ebi-a-GCST004904	GRCh37	East Asian	158284			Body mass index
-opengwas	ebi-a	GWAS	./dataset/ebi-a-GCST004770.gwaslab.tsv.sampled.gz			ebi-a-GCST004770	GRCh37	Mixed	8327			Lean body mass
 opengwas	ieu-a	GWAS	./dataset/ieu-a-1089.gwaslab.tsv.sampled.gz	UK Biobank	Combined	ieu-a-1089	GRCh37	European	120286			Body mass index
 opengwas	ieu-a	GWAS	./dataset/ieu-a-2.gwaslab.tsv.sampled.gz	GIANT	Combined	ieu-a-2	GRCh37	Mixed	338224			Body mass index
 opengwas	ieu-a	GWAS	./dataset/ieu-a-785.gwaslab.tsv.sampled.gz	GIANT	Males	ieu-a-785	GRCh37	European	152893			Body mass index

--- a/data/out_meta.csv
+++ b/data/out_meta.csv
@@ -1,4 +1,25 @@
-project,study,category,data_id,build,population,notes.sex,notes.source_id,total.samples,total.cases,total.controls,trait.desc
-UKB,d,GWAS,95386150a6,GRCh37,European,Males and Females,ukb-d-XII_SKIN_SUBCUTAN,361194,27074,334120,Diseases of the skin and subcutaneous tissue
-UKB,d,GWAS,f588175d46,GRCh37,European,Males and Females,ukb-d-Z42,361194,1963,359231,Diagnoses - main ICD10: Z42 Follow-up care involving plastic surgery
-UKB,d,GWAS,3440ed14ff,GRCh37,European,Males and Females,ukb-d-XV_PREGNANCY_BIRTH,361194,11959,349235,"Pregnancy, childbirth and the puerperium"
+project,study,category,data_id,build,population,notes_consortium,notes_sex,notes_source_id,total_samples,total_cases,total_controls,trait_desc,output_prefix
+opengwas,bbj-a,GWAS,92df1d8ed4,GRCh37,['East Asian'],,Combined,bbj-a-1,158284,,,Body mass index,../scripts/tests/01/example_export_bbj-a-1
+opengwas,bbj-a,GWAS,45755df18d,GRCh37,['East Asian'],,Males,bbj-a-2,85894,,,Body mass index,../scripts/tests/01/example_export_bbj-a-2
+opengwas,bbj-a,GWAS,d4a398afe7,GRCh37,['East Asian'],,Females,bbj-a-3,72390,,,Body mass index,../scripts/tests/01/example_export_bbj-a-3
+opengwas,ebi-a,GWAS,4e047a2aff,GRCh37,['East Asian'],,,ebi-a-GCST004904,158284,,,Body mass index,../scripts/tests/01/example_export_ebi-a-GCST004904
+opengwas,ebi-a,GWAS,ca4d6dc0aa,GRCh37,['Mixed'],,,ebi-a-GCST004770,8327,,,Lean body mass,../scripts/tests/01/example_export_ebi-a-GCST004770
+opengwas,ieu-a,GWAS,fcdc6e9e75,GRCh37,['European'],UK Biobank,Combined,ieu-a-1089,120286,,,Body mass index,../scripts/tests/01/example_export_ieu-a-1089
+opengwas,ieu-a,GWAS,9345f466a2,GRCh37,['Mixed'],GIANT,Combined,ieu-a-2,338224,,,Body mass index,../scripts/tests/01/example_export_ieu-a-2
+opengwas,ieu-a,GWAS,8911a276d6,GRCh37,['European'],GIANT,Males,ieu-a-785,152893,,,Body mass index,../scripts/tests/01/example_export_ieu-a-785
+opengwas,ieu-a,GWAS,8a61fd1240,GRCh37,['European'],GIANT,Combined,ieu-a-85,16068,7962.0,8106.0,Extreme body mass index,../scripts/tests/01/example_export_ieu-a-85
+opengwas,ieu-a,GWAS,d43e3983cd,GRCh37,['European'],GIANT,Females,ieu-a-974,171977,,,Body mass index,../scripts/tests/01/example_export_ieu-a-974
+opengwas,ieu-b,GWAS,5626f7d056,GRCh37,['European'],GIANT,Combined,ieu-b-40,681275,,,body mass index,../scripts/tests/01/example_export_ieu-b-40
+opengwas,ieu-b,GWAS,89f31189b3,GRCh37,['European'],GIANT,Females,ieu-b-5117,246511,,,Adult BMI females,../scripts/tests/01/example_export_ieu-b-5117
+opengwas,ukb-a,GWAS,e69866be25,GRCh37,['European'],Neale Lab,Combined,ukb-a-248,336107,,,Body mass index (BMI),../scripts/tests/01/example_export_ukb-a-248
+opengwas,ukb-a,GWAS,c29c626f94,GRCh37,['European'],Neale Lab,Combined,ukb-a-264,336107,,,Body fat percentage,../scripts/tests/01/example_export_ukb-a-264
+opengwas,ukb-b,GWAS,be0fa663d4,GRCh37,['European'],MRC-IEU,Combined,ukb-b-19953,454137,,,Whole body fat mass,../scripts/tests/01/example_export_ukb-b-19953
+opengwas,ukb-b,GWAS,a9497f792c,GRCh37,['European'],MRC-IEU,Combined,ukb-b-2303,454884,,,Body mass index (BMI),../scripts/tests/01/example_export_ukb-b-2303
+opengwas,ukb-e,GWAS,ea708dfd8b,GRCh37,['African American or Afro-Caribbean'],,Combined,ukb-e-21001_AFR,6545,6545.0,,Body mass index (BMI),../scripts/tests/01/example_export_ukb-e-21001_AFR
+opengwas,ukb-e,GWAS,e9ea240d0e,GRCh37,['South Asian'],,Combined,ukb-e-21001_CSA,8646,8646.0,,Body mass index (BMI),../scripts/tests/01/example_export_ukb-e-21001_CSA
+opengwas,ukb-e,GWAS,d5cf224253,GRCh37,['African American or Afro-Caribbean'],,Combined,ukb-e-23104_AFR,6458,6458.0,,Body mass index (BMI),../scripts/tests/01/example_export_ukb-e-23104_AFR
+opengwas,ukb-e,GWAS,521cded1f7,GRCh37,['South Asian'],,Combined,ukb-e-23104_CSA,8658,8658.0,,Body mass index (BMI),../scripts/tests/01/example_export_ukb-e-23104_CSA
+opengwas,ukb-d,GWAS,1b7d38093c,GRCh38,['European'],,Combined,ukb-d-XVIII_MISCFINDINGS,361194,97602.0,263592.0,"Symptoms, signs and abnormal clinical and laboratory findings, not elsewhere classified",../scripts/tests/01/example_export_ukb-d-XVIII_MISCFINDINGS
+opengwas,ukb-d,GWAS,93785777bd,GRCh38,['European'],,Combined,ukb-d-XII_SKIN_SUBCUTAN,361194,27074.0,334120.0,Diseases of the skin and subcutaneous tissue,../scripts/tests/01/example_export_ukb-d-XII_SKIN_SUBCUTAN
+opengwas,ukb-d,GWAS,845c521c74,GRCh38,['European'],,Combined,ukb-d-XV_PREGNANCY_BIRTH,361194,11959.0,349235.0,"Pregnancy, childbirth and the puerperium",../scripts/tests/01/example_export_ukb-d-XV_PREGNANCY_BIRTH
+opengwas,ukb-d,GWAS,d521224bd3,GRCh38,['European'],,Combined,ukb-d-Z01,361194,1370.0,359824.0,Diagnoses - main ICD10: Z01 Other special examinations and investigations of persons without complaint or reported diagnosis,../scripts/tests/01/example_export_ukb-d-Z01

--- a/data/search_example_06.yml
+++ b/data/search_example_06.yml
@@ -1,0 +1,23 @@
+project: opengwas
+category: GWAS
+notes:
+  - consortium: GIANT
+  - consortium: MRC-IEU
+trait:
+  - desc: Body Mass Index
+  - desc: BMI
+data_ids:
+  - 89f31189b3
+  - a9497f792c
+
+
+output:
+  - build
+  - population
+  - notes_consortium
+  - notes_sex
+  - notes_source_id
+  - total_samples
+  - total_cases
+  - total_controls
+  - trait_desc

--- a/scripts/test_00.sh
+++ b/scripts/test_00.sh
@@ -15,7 +15,7 @@ fi
 
 # Define the data and test directory variables
 GWASSTUDIO_DATA_DIR=$(gwasstudio info | grep "data dir:" | awk -F': ' '{print $2}')
-TEST_DIR="../../scripts/tests/00"
+TEST_DIR="../scripts/tests/00"
 MDB_URI="mongodb://localhost:27018/test_00"
 TILEDB_DIR="${TEST_DIR}/tiledB"
 

--- a/scripts/test_01.sh
+++ b/scripts/test_01.sh
@@ -15,7 +15,7 @@ fi
 
 # Define the data and test directory variables
 GWASSTUDIO_DATA_DIR=$(gwasstudio info | grep "data dir:" | awk -F': ' '{print $2}')
-TEST_DIR="../../scripts/tests/01"
+TEST_DIR="../scripts/tests/01"
 MDB_URI="mongodb://localhost:27018/test_01"
 TILEDB_DIR="${TEST_DIR}/tiledB"
 
@@ -47,6 +47,9 @@ run_command "Querying data..." "time gwasstudio --stdout --mongo-uri ${MDB_URI} 
 
 # Query data by trait description
 run_command "Querying data by trait description..." "time gwasstudio --stdout --mongo-uri ${MDB_URI} meta-query --search-file search_example_04.yml --output-prefix ${TEST_DIR}/example_query_by_trait_desc"
+
+# Query data by data_ids - it is a precision query, only 2 results expected
+run_command "Querying data by data_ids..." "time gwasstudio --stdout --mongo-uri ${MDB_URI} meta-query --search-file search_example_06.yml --output-prefix ${TEST_DIR}/example_query_by_trait_desc"
 
 # Export data
 run_command "Exporting data..." "time gwasstudio --stdout --mongo-uri ${MDB_URI} export --search-file search_example_01.yml --output-prefix ${TEST_DIR}/example_export --uri ${TILEDB_DIR}"

--- a/scripts/test_02.sh
+++ b/scripts/test_02.sh
@@ -15,7 +15,7 @@ fi
 
 # Define the data and test directory variables
 GWASSTUDIO_DATA_DIR=$(gwasstudio info | grep "data dir:" | awk -F': ' '{print $2}')
-TEST_DIR="../../scripts/tests/02"
+TEST_DIR="../scripts/tests/02"
 MDB_URI="mongodb://localhost:27018/test_02"
 TILEDB_DIR="${TEST_DIR}/tiledB"
 


### PR DESCRIPTION
This commit enhances the Mongo query composition process in the `MongoMixin` class. It now allows querying by data IDs, making it more flexible for precise data retrieval. Additionally, queries from regular key-value pairs are combined with AND logic, improving overall query functionality. 
See data/search_example_06.yml