### PR TITLE
feat: Add output prefix dictionary generator

### DIFF
--- a/src/gwasstudio/utils/enums.py
+++ b/src/gwasstudio/utils/enums.py
@@ -39,7 +39,7 @@ class BaseEnum(Enum):
 
     @classmethod
     def get_all_dtypes_dict(cls) -> dict:
-        return {member.get_value: member.get_dtype() for member in cls}
+        return {member.get_value(): member.get_dtype() for member in cls}
 
 
 class MetadataEnum(BaseEnum):
@@ -47,8 +47,11 @@ class MetadataEnum(BaseEnum):
     STUDY = ("study", DataType.CATEGORY)
     FILE_PATH = ("file_path", DataType.STRING_PA)
     CATEGORY = ("category", DataType.CATEGORY)
+    DATA_ID = ("data_id", DataType.STRING_PA)
     BUILD = ("build", DataType.CATEGORY)
     CONSORTIUM = ("notes_consortium", DataType.STRING_PA)
+    SEX = ("notes_sex", DataType.CATEGORY)
+    SOURCE_ID = ("notes_source_id", DataType.STRING_PA)
     SAMPLES = ("total_samples", DataType.UINT64_PA)
     CASES = ("total_cases", DataType.UINT64_PA)
     CONTROLS = ("total_controls", DataType.UINT64_PA)
@@ -56,9 +59,15 @@ class MetadataEnum(BaseEnum):
 
     @classmethod
     def required_fields(cls):
+        """It returns a list of required fields for ingestion"""
         return [
-            cls.PROJECT.value,
-            cls.STUDY.value,
-            cls.FILE_PATH.value,
-            cls.CATEGORY.value,
+            cls.PROJECT.get_value(),
+            cls.STUDY.get_value(),
+            cls.FILE_PATH.get_value(),
+            cls.CATEGORY.get_value(),
         ]
+
+    @classmethod
+    def get_source_id_field(cls):
+        """It returns the metadata field name that store source ids"""
+        return cls.SOURCE_ID.get_value()

--- a/tests/unit/test_export_utils.py
+++ b/tests/unit/test_export_utils.py
@@ -1,0 +1,57 @@
+import unittest
+
+import pandas as pd
+
+from gwasstudio.cli.export import create_output_prefix_dict
+from gwasstudio.utils.enums import MetadataEnum
+
+
+class TestCreateOutputPrefixDict(unittest.TestCase):
+    def setUp(self) -> None:
+        self.source_id_field = MetadataEnum.get_source_id_field()
+
+    def test_source_id_column_exists_and_has_no_nans(self):
+        """Test when source_id_column exists and has no NaNs."""
+        data = {
+            "data_id": pd.Series([101, 102, 103], dtype="string"),
+            "notes_source_id": pd.Series([456, 789, 104], dtype="string"),
+        }
+        df = pd.DataFrame(data)
+        output_prefix = "output"
+
+        result = create_output_prefix_dict(df, output_prefix, source_id_column=self.source_id_field)
+
+        self.assertEqual(result, {"101": "output_456", "102": "output_789", "103": "output_104"})
+
+    def test_source_id_column_has_nans(self):
+        """Test when source_id_column has some NaNs."""
+        data = {
+            "data_id": pd.Series([101, 102, 103], dtype="string"),
+            "notes_source_id": pd.Series([456, None, 104], dtype="string"),
+        }
+
+        df = pd.DataFrame(data)
+        output_prefix = "output"
+
+        result = create_output_prefix_dict(df, output_prefix, source_id_column=self.source_id_field)
+
+        self.assertEqual(result, {"101": "output_456", "102": "output_102", "103": "output_104"})
+
+    def test_source_id_column_does_not_exist(self):
+        """Test when source_id_column is not present in the DataFrame."""
+        data = {"data_id": pd.Series([101, 102, 103], dtype="string")}
+        df = pd.DataFrame(data)
+        output_prefix = "output"
+
+        result = create_output_prefix_dict(df, output_prefix, source_id_column=self.source_id_field)
+
+        self.assertEqual(result, {"101": "output_101", "102": "output_102", "103": "output_103"})
+
+    def test_empty_dataframe(self):
+        """Test empty DataFrame returns an empty dictionary."""
+        df = pd.DataFrame(columns=["data_id", "notes_source_id"])
+        output_prefix = "output"
+
+        result = create_output_prefix_dict(df, output_prefix, source_id_column=self.source_id_field)
+
+        self.assertEqual(result, {})


### PR DESCRIPTION
introduces a new function `create_output_prefix_dict` in the `gwasstudio.cli.export` module, which generates a dictionary mapping data IDs to output prefixes based on column values in an input DataFrame. It also fixes the case when source ids are not available.