### PR TITLE
Keep dask graph small

### DIFF
--- a/src/gwasstudio/cli/export.py
+++ b/src/gwasstudio/cli/export.py
@@ -1,4 +1,6 @@
+import math
 from pathlib import Path
+from typing import Callable
 
 import click
 import cloup
@@ -16,6 +18,7 @@ from gwasstudio.utils.cfg import get_mongo_uri, get_tiledb_config, get_dask_batc
 from gwasstudio.utils.enums import MetadataEnum
 from gwasstudio.utils.metadata import load_search_topics, query_mongo_obj, dataframe_from_mongo_objs
 from gwasstudio.utils.mongo_manager import manage_mongo
+from gwasstudio.utils.path_joiner import join_path
 
 
 def create_output_prefix_dict(df: pd.DataFrame, output_prefix: str, source_id_column: str) -> dict:
@@ -48,34 +51,79 @@ def create_output_prefix_dict(df: pd.DataFrame, output_prefix: str, source_id_co
     return output_prefix_dict
 
 
-def _process_function_tasks(tiledb_array, trait_id_list, attr, batch_size, output_prefix_dict, output_format, **kwargs):
-    """This function schedules and executes generic delayed tasks for various export processes"""
+def _process_function_tasks(
+    tiledb_uri: str,
+    tiledb_cfg: dict[str, str],
+    trait_id_list: list[str],
+    attr: str,
+    batch_size: int,
+    output_prefix_dict: dict[str, str],
+    output_format: str,
+    *,
+    function_name: Callable,
+    snp_list_file: str | None = None,
+    **kwargs,
+) -> None:
+    """
+    Schedule and execute delayed export tasks.
 
-    def get_snp_list(input_filepath: str | None) -> pd.DataFrame | None:
-        if not input_filepath:
+    Parameters
+    ----------
+    tiledb_uri : str
+        URI of the TileDB array (e.g. ``s3://my-bucket/dataset``).
+        The array is opened *inside* each worker, never serialized.
+    function_name : Callable
+        One of the extraction functions (``extract_full_stats``, …).
+    """
+
+    # Helper: read SNP list lazily
+    def _read_snp_list(fp: str) -> pd.DataFrame | None:
+        if not fp:
             return None
+        df = pd.read_csv(fp, usecols=["CHR", "POS"], dtype={"CHR": str, "POS": int})
+        return df[df["CHR"].str.isnumeric()]
 
-        snp_list = pd.read_csv(input_filepath, usecols=["CHR", "POS"], dtype={"CHR": str, "POS": int})
-        return snp_list[snp_list["CHR"].str.isnumeric()]
+    # Wrapper that opens the array locally and forwards the call.
+    @delayed
+    def _run_extraction(
+        uri: str,
+        cfg: dict[str, str],
+        trait: str,
+        out_prefix: str | None,
+        fmt: str,
+        **inner_kwargs,
+    ) -> None:
+        """Open the TileDB array on the worker and invoke ``function_name``."""
+        # Open a *read‑only* handle on the worker.
+        with tiledb.open(uri, mode="r", config=cfg) as arr:
+            # ``function_name`` expects the opened array as its first argument.
+            return function_name(arr, trait, out_prefix, fmt, **inner_kwargs)
 
-    function_name = kwargs.pop("function_name", None)
-    snp_list_file = kwargs.pop("snp_list_file", None)
-
+    # Prepare kwargs for the downstream extraction routine.
     kwargs["attributes"] = attr.split(",") if attr else None
     if snp_list_file:
-        kwargs["snp_list"] = delayed(get_snp_list)(snp_list_file)
+        kwargs["snp_list"] = delayed(_read_snp_list)(snp_list_file)
 
-    tasks = [
-        delayed(function_name)(tiledb_array, trait, output_prefix_dict.get(trait), output_format, **kwargs)
+    # Build the delayed tasks – each task receives the URI, not the object.
+    tasks: list[delayed] = [
+        _run_extraction(
+            tiledb_uri,
+            tiledb_cfg,
+            trait,
+            output_prefix_dict.get(trait),
+            output_format,
+            **kwargs,
+        )
         for trait in trait_id_list
     ]
+
+    # Execute in batches (keeps the Dask graph small).
     for i in range(0, len(tasks), batch_size):
-        logger.info(f"Processing a batch of {batch_size} items for batch {i // batch_size + 1}")
-        # Create a list of delayed tasks
-        # Submit tasks and wait for completion
-        batch = tasks[i : i + batch_size]
-        compute(*batch)
-        logger.info(f"Batch {i // batch_size + 1} completed.", flush=True)
+        batch_no = i // batch_size + 1
+        total_batches = math.ceil(len(tasks) / batch_size)
+        logger.info(f"Processing batch {batch_no}/{total_batches} ({batch_size} items)")
+        compute(*tasks[i : i + batch_size])
+        logger.info(f"Batch {batch_no} completed.", flush=True)
 
 
 HELP_DOC = """
@@ -230,55 +278,65 @@ def export(
         batch_size = get_dask_batch_size(ctx)
         grouped = df.groupby(MetadataEnum.get_tiledb_grouping_fields(), observed=False)
         for name, group in grouped:
-            logger.info(f"Processing the group {'_'.join(name)}")
-            trait_id_list = list(group["data_id"])
+            group_name = "_".join(name)
+            logger.info(f"Processing the group {group_name}")
+            trait_ids = list(group["data_id"])
+            tiledb_uri = join_path(uri, group_name)
+            logger.debug(f"tiledb_uri: {tiledb_uri}")
 
-            tiledb_uri = str(Path(uri) / "_".join(name))
+            # Common argument list
+            common_args = [
+                tiledb_uri,  # <-- URI, not an opened array
+                cfg,
+                trait_ids,
+                attr,
+                batch_size,
+                output_prefix_dict,
+                output_format,
+            ]
 
-            # Open TileDB dataset
-            with tiledb.open(tiledb_uri, mode="r", config=cfg) as tiledb_array:
-                logger.info("TileDB dataset loaded")
-                args = [tiledb_array, trait_id_list, attr, batch_size, output_prefix_dict, output_format]
-
-                if locusbreaker:
-                    kwargs = {
-                        "function_name": _process_locusbreaker,
-                        "maf": maf,
-                        "hole_size": hole_size,
-                        "pvalue_sig": pvalue_sig,
-                        "pvalue_limit": pvalue_limit,
-                        "phenovar": phenovar,
-                    }
-                    _process_function_tasks(*args, **kwargs)
-
-                elif snp_list_file:
-                    kwargs = {
-                        "function_name": extract_snp_list,
-                        "snp_list_file": snp_list_file,
-                        "plot_out": plot_out,
-                        "color_thr": color_thr,
-                        "s_value": s_value,
-                    }
-                    _process_function_tasks(*args, **kwargs)
-
-                elif get_regions:
-                    bed_region = pd.read_csv(get_regions, sep="\t", header=None)
-                    bed_region.columns = ["CHR", "START", "END"]
+            # Dispatch the appropriate extraction routine
+            match (locusbreaker, snp_list_file, get_regions):
+                case (True, _, _):
+                    _process_function_tasks(
+                        *common_args,
+                        function_name=_process_locusbreaker,
+                        maf=maf,
+                        hole_size=hole_size,
+                        pvalue_sig=pvalue_sig,
+                        pvalue_limit=pvalue_limit,
+                        phenovar=phenovar,
+                    )
+                case (_, str() as snp_fp, _):
+                    _process_function_tasks(
+                        *common_args,
+                        function_name=extract_snp_list,
+                        snp_list_file=snp_fp,
+                        plot_out=plot_out,
+                        color_thr=color_thr,
+                        s_value=s_value,
+                    )
+                case (_, _, str() as bed_fp):
+                    bed_region = pd.read_csv(
+                        bed_fp,
+                        sep="\t",
+                        header=None,
+                        names=["CHR", "START", "END"],
+                    )
                     bed_region["CHR"] = bed_region["CHR"].astype(int)
-                    kwargs = {
-                        "function_name": extract_regions,
-                        "bed_region": bed_region.groupby("CHR"),
-                        "plot_out": plot_out,
-                        "color_thr": color_thr,
-                        "s_value": s_value,
-                    }
-                    _process_function_tasks(*args, **kwargs)
-
-                else:
-                    kwargs = {
-                        "function_name": extract_full_stats,
-                        "plot_out": plot_out,
-                        "color_thr": color_thr,
-                        "s_value": s_value,
-                    }
-                    _process_function_tasks(*args, **kwargs)
+                    _process_function_tasks(
+                        *common_args,
+                        function_name=extract_regions,
+                        bed_region=bed_region.groupby("CHR"),
+                        plot_out=plot_out,
+                        color_thr=color_thr,
+                        s_value=s_value,
+                    )
+                case _:
+                    _process_function_tasks(
+                        *common_args,
+                        function_name=extract_full_stats,
+                        plot_out=plot_out,
+                        color_thr=color_thr,
+                        s_value=s_value,
+                    )

--- a/src/gwasstudio/cli/export.py
+++ b/src/gwasstudio/cli/export.py
@@ -1,9 +1,9 @@
-import math
 from pathlib import Path
 from typing import Callable
 
 import click
 import cloup
+import math
 import pandas as pd
 import tiledb
 from dask import delayed, compute
@@ -117,11 +117,11 @@ def _process_function_tasks(
         for trait in trait_id_list
     ]
 
+    total_batches = math.ceil(len(tasks) / batch_size)
     # Execute in batches (keeps the Dask graph small).
     for i in range(0, len(tasks), batch_size):
         batch_no = i // batch_size + 1
-        total_batches = math.ceil(len(tasks) / batch_size)
-        logger.info(f"Processing batch {batch_no}/{total_batches} ({batch_size} items)")
+        logger.info(f"Running batch {batch_no}/{total_batches} ({batch_size} items)")
         compute(*tasks[i : i + batch_size])
         logger.info(f"Batch {batch_no} completed.", flush=True)
 

--- a/src/gwasstudio/utils/path_joiner.py
+++ b/src/gwasstudio/utils/path_joiner.py
@@ -1,0 +1,128 @@
+"""
+Utility for joining filesystem paths and S3 URIs.
+
+Typical usage
+-------------
+# >>> from path_joiner import join_path
+# >>> join_path("/tmp/data", "destination")
+'/tmp/data/destination'
+
+# >>> join_path("s3://my-bucket/data", "destination")
+'s3://my-bucket/data/destination'
+
+The function works with any number of extra components:
+
+# >>> join_path("s3://my-bucket", "a", "b", "c")
+'s3://my-bucket/a/b/c'
+
+It also copes with stray slashes, empty components and
+different OS path conventions.
+"""
+
+from pathlib import PurePosixPath, Path
+from urllib.parse import urlparse, urlunparse
+
+
+def _is_uri(s: str) -> bool:
+    """
+    Very small helper – returns ``True`` if *s* looks like a URI
+    (i.e. it has a non‑empty scheme part).
+
+    We deliberately treat only ``scheme://`` as a URI; a leading ``/``
+    is considered a plain local path.
+    """
+    return bool(urlparse(s).scheme)
+
+
+def _join_posix(base: str, *parts: str) -> str:
+    """
+    Join *base* and *parts* using POSIX semantics (forward slash).
+    This is the logic we want for S3 keys and for any path that
+    already uses forward slashes (including Unix paths on Windows).
+
+    ``PurePosixPath`` never touches the actual filesystem – it simply
+    manipulates strings.
+    """
+    p = PurePosixPath(base)
+    for part in parts:
+        p = p / part
+    return str(p)
+
+
+def join_path(base: str, *parts: str) -> str:
+    """
+    Join a base location with one or more path components.
+
+    Parameters
+    ----------
+    base:
+        Either a plain filesystem path (e.g. ``/a/b`` or ``C:\\a\\b``) or
+        an S3 URI such as ``s3://my-bucket/a/b``.
+    *parts:
+        Additional components to append to *base*.  Empty strings or
+        strings consisting only of slashes are ignored.
+
+    Returns
+    -------
+    str
+        The combined path/URI.
+
+    Raises
+    ------
+    ValueError
+        If *base* is an empty string.
+
+    Examples
+    --------
+    >>> join_path("/tmp", "data", "dest")
+    '/tmp/data/dest'
+
+    >>> join_path("s3://my-bucket", "folder", "file.txt")
+    's3://my-bucket/folder/file.txt'
+    """
+    if not base:
+        raise ValueError("base path must be a non‑empty string")
+
+    # Normalise the extra parts – strip leading/trailing slashes,
+    # drop empty entries.
+    clean_parts = [p.strip("/") for p in parts if p and p.strip("/")]
+
+    # ------------------------------------------------------------------
+    # 1️⃣  S3‑style URIs (or any URI with a scheme) – treat everything
+    #     after the scheme:// as a POSIX path.
+    # ------------------------------------------------------------------
+    if _is_uri(base):
+        parsed = urlparse(base)
+
+        # Preserve the original scheme (e.g. "s3") and netloc (bucket name)
+        # but join the path part with the extra components using POSIX logic.
+        joined_path = _join_posix(parsed.path, *clean_parts)
+
+        # ``urlunparse`` expects a 6‑tuple; we keep the original query,
+        # fragment, params, etc. unchanged.
+        rebuilt = urlunparse(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                joined_path,
+                parsed.params,
+                parsed.query,
+                parsed.fragment,
+            )
+        )
+        return rebuilt
+
+    # ------------------------------------------------------------------
+    # 2️⃣  Plain filesystem path.
+    # ------------------------------------------------------------------
+    # On Windows we must respect the native separator.  ``Path`` does that.
+    # If the base path already uses forward slashes we still want the
+    # correct OS‑specific behaviour, so we convert it to a ``Path`` first.
+    p = Path(base)
+
+    for part in clean_parts:
+        p = p / part
+
+    # ``Path`` will automatically use ``os.sep`` for the current platform.
+    # For consistency with the examples we return a string.
+    return str(p)

--- a/tests/unit/test_utils_path_joiner.py
+++ b/tests/unit/test_utils_path_joiner.py
@@ -1,0 +1,161 @@
+# ------------------------------------------------------------
+# file: test_path_joiner.py
+# ------------------------------------------------------------
+"""
+Pytest suite for the ``join_path`` function defined in
+path_joiner.py.
+
+The tests cover:
+
+* plain POSIX and Windows filesystem paths,
+* S3 URIs (including bucket‑only URIs),
+* the “file://” scheme,
+* handling of stray leading/trailing slashes,
+* empty/None components (they should be ignored),
+* error handling for an empty base string.
+"""
+
+import os
+import sys
+
+import pytest
+
+# Import the function we are testing.
+# Adjust the import if your module lives in a package.
+from gwasstudio.utils.path_joiner import join_path
+
+
+# ----------------------------------------------------------------------
+# Helper – compute the native‑separator version of a POSIX path.
+# ----------------------------------------------------------------------
+def native_path(posix_path: str) -> str:
+    """
+    Convert a POSIX style path (using forward slashes) to the
+    current OS's native representation.  On Unix this is a no‑op,
+    on Windows it turns '/' into '\\'.
+    """
+    return posix_path.replace("/", os.sep)
+
+
+# ----------------------------------------------------------------------
+# 1️⃣  Filesystem‑only tests
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "base,parts,expected",
+    [
+        # Simple POSIX join
+        ("/tmp", ["data"], "/tmp/data"),
+        ("/tmp/", ["data"], "/tmp/data"),
+        ("/tmp", ["data", "sub"], "/tmp/data/sub"),
+        # Leading/trailing slashes on parts must be stripped
+        ("/tmp", ["/data/"], "/tmp/data"),
+        ("/tmp/", ["/data/", "/sub/"], "/tmp/data/sub"),
+        # Empty strings are ignored
+        ("/tmp", ["", "data"], "/tmp/data"),
+        ("/tmp", ["data", ""], "/tmp/data"),
+        # Windows native paths – only run on Windows to avoid false failures
+        pytest.param(
+            r"C:\Users\bob",
+            ["docs", "report.txt"],
+            r"C:\Users\bob\docs\report.txt",
+            marks=pytest.mark.skipif(
+                not sys.platform.startswith("win"),
+                reason="Windows‑specific path test",
+            ),
+        ),
+        # Mixed forward‑slash input on Windows – should still end up native
+        pytest.param(
+            r"C:/temp",
+            ["folder", "file.txt"],
+            r"C:\temp\folder\file.txt",
+            marks=pytest.mark.skipif(
+                not sys.platform.startswith("win"),
+                reason="Windows‑specific path test",
+            ),
+        ),
+    ],
+)
+def test_filesystem_paths(base, parts, expected):
+    assert join_path(base, *parts) == expected
+
+
+# ----------------------------------------------------------------------
+# 2️⃣  S3‑style URI tests
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "base,parts,expected",
+    [
+        # Bucket only + one component
+        ("s3://my-bucket", ["data"], "s3://my-bucket/data"),
+        # Bucket + prefix + many components
+        ("s3://my-bucket/prefix", ["a", "b", "c"], "s3://my-bucket/prefix/a/b/c"),
+        # Trailing/leading slashes on parts must be stripped
+        ("s3://my-bucket/prefix/", ["/a/", "/b/"], "s3://my-bucket/prefix/a/b"),
+        # Empty parts are ignored
+        ("s3://my-bucket", ["", "x"], "s3://my-bucket/x"),
+        # Preserve query/fragment if they exist
+        (
+            "s3://my-bucket/prefix?versionId=123#section",
+            ["file.txt"],
+            "s3://my-bucket/prefix/file.txt?versionId=123#section",
+        ),
+    ],
+)
+def test_s3_uris(base, parts, expected):
+    assert join_path(base, *parts) == expected
+
+
+# ----------------------------------------------------------------------
+# 3️⃣  Other URI schemes (file://, http://, etc.)
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "base,parts,expected",
+    [
+        ("file:///var/log", ["app.log"], "file:///var/log/app.log"),
+        ("http://example.com/api", ["v1", "users"], "http://example.com/api/v1/users"),
+        # Even though we mainly care about S3, the logic works for any scheme.
+    ],
+)
+def test_generic_uris(base, parts, expected):
+    assert join_path(base, *parts) == expected
+
+
+# ----------------------------------------------------------------------
+# 4️⃣  Edge‑case / error handling
+# ----------------------------------------------------------------------
+def test_empty_base_raises():
+    """An empty base string should raise a ValueError."""
+    with pytest.raises(ValueError):
+        join_path("", "anything")
+
+
+def test_none_parts_are_ignored():
+    """
+    ``None`` (or any falsy value) in *parts* should be treated like an empty
+    string and simply ignored.
+    """
+    assert join_path("/tmp", None, "data", "", "sub") == "/tmp/data/sub"
+
+
+# ----------------------------------------------------------------------
+# 5️⃣  Idempotency – calling join_path on an already‑joined result
+# ----------------------------------------------------------------------
+def test_idempotent_join():
+    """
+    ``join_path`` should be safe to call repeatedly; the result of a join
+    is a valid *base* for a subsequent call.
+    """
+    first = join_path("s3://bucket/folder", "sub1")
+    second = join_path(first, "sub2")
+    assert second == "s3://bucket/folder/sub1/sub2"
+
+
+# ----------------------------------------------------------------------
+# 6️⃣  Mixed‑type inputs (bytes → str conversion is not supported)
+# ----------------------------------------------------------------------
+def test_non_string_input():
+    """Only strings are accepted – other types raise a TypeError."""
+    with pytest.raises(TypeError):
+        # ``bytes`` does not have ``strip`` – our implementation will
+        # raise an AttributeError before any custom check.
+        join_path(b"s3://bucket", "key")


### PR DESCRIPTION
Avoid sending live TileDB objects across the network 

TileDB arrays hold an internal C++ pointer to the underlying VFS and file handles. When you pickle them (as Dask does when you place an Array in a task graph), they attempt to re‑open the array on the remote worker (via preload_array). This re‑open is exactly where the error appears. 

Best practice: Never send a tiledb.Array instance directly in a Dask task. Instead: 
    Pass the URI ("s3://tiledb/opengwas_ukb-a/") and let each worker open its own handle.