### PR TITLE
Add inline string option for --get-regions-snps input

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,6 @@ repos:
       - id: check-yaml
       - id: check-toml
       - id: detect-private-key
-      - id: detect-aws-credentials
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.14.0

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,11 +33,15 @@ gwasstudio export [OPTIONS]
 
 **Regions and SNP ID List Filtering Options:**
 
-- `--get-regions-snps TEXT`: Bed file (or txt file with CHR and POS columns) with regions or SNPs to filter.
+- `--get-regions-snps TEXT`:
+  - A valid BED (CHR\tSTART\tEND) file path or
+  - A valid SNP list (CHR,POS) file path or
+  - An inline string: "CHR,START,END;CHR,START,END" for regions; "CHR,POS;CHR,POS" for SNPs
 - `--pvalue-filt FLOAT`: Minimum -log10(p-value) threshold to keep significant filtered SNPs (default: 0, no filter)
 - `--nest`: Estimate effective population size (Work in progress, not fully implemented yet) (flag).
 
 **Trait-specific Lead-SNP Search Options:**
+
 - `--get-regions-leadsnps TEXT`: A DataFrame containing SOURCE_ID (trait), CHR, POS, EA and NEA (and optionally CIS_TRANS) for lead-SNP search.
 - `--cis-flanks INTEGER`: Flanking region (in bp) around POS for the search of CIS lead-SNP (default: 500000).
 - `--trans-flanks INTEGER`: Flanking region (in bp) around POS for the search of TRANS lead-SNP (default: 1000000).

--- a/scripts/test_01.sh
+++ b/scripts/test_01.sh
@@ -75,8 +75,14 @@ run_command "Regions filtering..." "gwasstudio --stdout --mongo-uri ${MDB_URI} e
 # Regions filtering with P-value threshold
 run_command "Regions filtering with P-value threshold..." "gwasstudio --stdout --mongo-uri ${MDB_URI} export --search-file search_example_01.yml --output-prefix ${TEST_DIR}/example_regions_filtering_pvalue --output-format csv --uri ${TILEDB_DIR} --get-regions-snps regions_query.tsv --pvalue-filt 7.30103"
 
+# Regions filtering
+run_command "Regions filtering..." "gwasstudio --stdout --mongo-uri ${MDB_URI} export --search-file search_example_01.yml --output-prefix ${TEST_DIR}/example_regions_filtering_by_arg --output-format csv --uri ${TILEDB_DIR} --get-regions-snps '13,23947562,94021213;15,471752,49338760'"
+
 # Hapmap3 SNPs filtering
 run_command "SNPs filtering..." "gwasstudio --stdout --workers 4 --mongo-uri ${MDB_URI} export --search-file search_example_01.yml --output-prefix ${TEST_DIR}/example_snps_filtering --uri ${TILEDB_DIR} --get-regions-snps hapmap3/hapmap3_snps.csv"
+
+# Hapmap3 SNPs filtering
+run_command "SNPs filtering..." "gwasstudio --stdout --workers 4 --mongo-uri ${MDB_URI} export --search-file search_example_01.yml --output-prefix ${TEST_DIR}/example_snps_filtering_by_arg --uri ${TILEDB_DIR} --get-regions-snps '1,203669100;3,193327134;5,154619144;9,6741529;11,691029;12,108349821;18,677302'"
 
 # Trait-specific lead-SNP search
 run_command "Lead-SNP search..." "gwasstudio --stdout --workers 4 --mongo-uri ${MDB_URI} export --search-file search_example_08.yml --output-prefix ${TEST_DIR}/example_leadsnp_search --uri ${TILEDB_DIR} --get-regions-leadsnps opengwas_prot-a_Prolactin_snps.csv"

--- a/src/gwasstudio/cli/export.py
+++ b/src/gwasstudio/cli/export.py
@@ -304,7 +304,7 @@ Export summary statistics from TileDB datasets with various filtering options.
     cloup.option(
         "--get-regions-snps",
         default=None,
-        help="Bed (or CHR,POS) file with regions or SNP list to filter",
+        help="BED (CHR\tSTART\tEND) or SNP list (CHR,POS) file paths, or string equivalents: (CHR,START,END;CHR,START,END) or (CHR,POS;CHR,POS)",
     ),
     cloup.option(
         "--pvalue-filt",

--- a/src/gwasstudio/utils/io.py
+++ b/src/gwasstudio/utils/io.py
@@ -1,61 +1,168 @@
 import pandas as pd
 
 from gwasstudio import logger
+from pathlib import Path
+from io import StringIO
 
 
-# Helper: read BED region file or SNP list
+# Helper: format chromosome
+def _clean_chr(df: pd.DataFrame, logger) -> pd.DataFrame:
+
+    # Remove 'chr' prefix and convert X/Y to 23/24
+    df.loc[:, "CHR"] = (
+        df["CHR"]
+        .astype(str)
+        .str.replace("chr", "", case=False)
+        .replace({"X": "23", "Y": "24"})
+    )
+
+    count_row_before = df.shape[0]
+    df = df[df["CHR"].str.isnumeric()]
+    row_diff = count_row_before - df.shape[0]
+    if row_diff > 0:
+        logger.warning(f"Removed {row_diff} rows with non-numeric CHR values.")
+
+    df.loc[:, "CHR"] = df["CHR"].astype(int)
+
+    return df
+
+
+# Helper: whether input is an existing path or not
+def _is_path(fp: str) -> bool:
+    try:
+        return Path(fp).exists()
+    except (OSError, ValueError):
+        return False
+
+
+# Helper: check correct format for inline string input
+# 2 columns -> SNP format (CHR,POS;CHR,POS)
+# 3 columns -> BED format (CHR,START,END;CHR,START,END)
+def _validate_string(fp: str) -> int:
+    expected_ncols = None
+
+    records = fp.split(";")
+    for record in records:
+        fields = record.split(",")
+        if any(not f.strip() for f in fields):
+            raise ValueError(f"Empty field in record: '{record}'")
+        ncols = len(fields)
+        if ncols not in (2, 3):
+            raise ValueError(
+                f"Invalid record '{record}'. "
+                "Expected CHR,POS or CHR,START,END"
+            )
+        if expected_ncols is None:
+            expected_ncols = ncols
+        elif ncols != expected_ncols:
+            raise ValueError(
+                f"Mixed inline in record '{record}'. "
+                "Use either CHR,POS or CHR,START,END consistently."
+            )
+
+    return expected_ncols
+
+
+# Helper: read BED region file or SNP list as:
+# 1) a file path
+# 2) an inline string
 def read_to_bed(fp: str) -> pd.DataFrame | None:
     if not fp:
         return None
-    try:
-        # Try BED format
-        df = pd.read_csv(
-            fp,
-            sep="\t",
-            header=None,
-            names=["CHR", "START", "END"],
-            usecols=range(3),
-            dtype={"CHR": str, "START": int, "END": int},
-        )
 
-        # Remove 'chr' prefix and convert X/Y to 23/24
-        df.loc[:, "CHR"] = df["CHR"].str.replace("chr", "", case=False)
-        df.loc[:, "CHR"] = df["CHR"].replace({"X": "23", "Y": "24"})
+    # File path input
+    if _is_path(fp):
 
-        count_row_before = df.shape[0]
-        df = df[df["CHR"].str.isnumeric()]
-        row_diff = count_row_before - df.shape[0]
-        if row_diff > 0:
-            logger.warning(f"Removed {row_diff} rows with non-numeric CHR values.")
+        try:
+            # BED format
+            df = pd.read_csv(
+                fp,
+                sep="\t",
+                header=None,
+                names=["CHR", "START", "END"],
+                usecols=range(3),
+                dtype={"CHR": str, "START": int, "END": int},
+            )
+            df = _clean_chr(df, logger)
 
-        df.loc[:, "CHR"] = df["CHR"].astype(int)
+            return df
+        except Exception as e:
+            logger.debug(f"Trying BED format failed: {e}")
 
-        return df
-    except Exception as e:
-        logger.debug(f"Trying to use BED format: {e}")
-        pass
-    try:
-        # Try SNP list and convert to BED format
-        df = pd.read_csv(fp, usecols=["CHR", "POS"], dtype={"CHR": str, "POS": int})
+        try:
+            # SNP list
+            df = pd.read_csv(
+                fp,
+                usecols=["CHR", "POS"],
+                dtype={"CHR": str, "POS": int},
+            )
+            df = _clean_chr(df, logger)
 
-        # Remove 'chr' prefix and convert X/Y to 23/24
-        df.loc[:, "CHR"] = df["CHR"].str.replace("chr", "", case=False)
-        df.loc[:, "CHR"] = df["CHR"].replace({"X": "23", "Y": "24"})
+            df = df.rename(columns={"POS": "START"})
+            df.loc[:, "END"] = df["START"] + 1
 
-        count_row_before = df.shape[0]
-        df = df[df["CHR"].str.isnumeric()]
-        row_diff = count_row_before - df.shape[0]
-        if row_diff > 0:
-            logger.warning(f"Removed {row_diff} rows with non-numeric CHR values.")
+            return df
+        except Exception as e:
+            logger.debug(f"Trying SNP list format failed: {e}")
 
-        df.loc[:, "CHR"] = df["CHR"].astype(int)
-        df = df.rename(columns={"POS": "START"})
-        df.loc[:, "END"] = df["START"] + 1
+            raise ValueError(
+                f"--get_regions_snps file '{fp}' should be "
+                "in BED format or SNP list format (CHR,POS)"
+            ) from e
+    
+    # Inline string input
+    else:
 
-        return df
-    except Exception as e:
-        logger.debug(f"Trying to use SNP list format: {e}")
-        raise ValueError(f"--get_regions_snps file '{fp}' should be in BED format or a SNP list (CHR,POS)")
+        try:
+            # Check inline string format
+            ncols = _validate_string(fp)
+
+            # Extract content from valid string
+            str_content = fp.replace(";", "\n")
+
+            # BED-like inline format
+            if ncols == 3:
+                df = pd.read_csv(
+                    StringIO(str_content),
+                    sep=",",
+                    header=None,
+                    names=["CHR", "START", "END"],
+                    dtype={"CHR": str, "START": int, "END": int},
+                )
+                df = _clean_chr(df, logger)
+
+                return df
+
+            # SNP-like inline format
+            elif ncols == 2:
+                df = pd.read_csv(
+                    StringIO(str_content),
+                    sep=",",
+                    header=None,
+                    names=["CHR", "POS"],
+                    dtype={"CHR": str, "POS": int},
+                )
+                df = _clean_chr(df, logger)
+
+                df = df.rename(columns={"POS": "START"})
+                df["END"] = df["START"] + 1
+
+                return df
+
+        except ValueError:
+            raise
+
+        # Wrong input format
+        except Exception as e:
+            raise ValueError(
+                "--get_regions_snps should be either:\n"
+                "1. A valid BED file\n"
+                "2. A valid SNP list file\n"
+                "3. An inline string:\n"
+                "   CHR,START,END;CHR,START,END\n"
+                "   or\n"
+                "   CHR,POS;CHR,POS"
+            ) from e
 
 
 # Helper: check valid allele ordering
@@ -80,18 +187,7 @@ def read_trait_snps(fp: str) -> pd.DataFrame | None:
             usecols=["SOURCE_ID", "CHR", "POS", "EA", "NEA"],
             dtype={"SOURCE_ID": str, "CHR": str, "POS": int, "EA": str, "NEA": str},
         )
-
-        # Remove 'chr' prefix and convert X/Y to 23/24
-        df.loc[:, "CHR"] = df["CHR"].str.replace("chr", "", case=False)
-        df.loc[:, "CHR"] = df["CHR"].replace({"X": "23", "Y": "24"})
-
-        count_row_before = df.shape[0]
-        df = df[df["CHR"].str.isnumeric()]
-        row_diff = count_row_before - df.shape[0]
-        if row_diff > 0:
-            logger.warning(f"Removed {row_diff} rows with non-numeric CHR values.")
-
-        df.loc[:, "CHR"] = df["CHR"].astype(int)
+        df = _clean_chr(df, logger)
 
         # Check if alleles are valid (alphabetically ordered)
         invalid_rows = []

--- a/tests/unit/test_read_bed.py
+++ b/tests/unit/test_read_bed.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import unittest
 
-from gwasstudio.utils.io import read_to_bed
+from gwasstudio.utils.io import read_to_bed, _is_path
 
 
 class TestReadToBed(unittest.TestCase):
@@ -26,6 +26,30 @@ chr2\t300\t400"""
         df = read_to_bed(fp)
         self.assertIsNotNone(df)
         self.assertListEqual(df["CHR"].tolist(), [1, 2])
+
+    def test_is_path_inline_regions(self):
+        self.assertFalse(_is_path("1,100,200;2,300,400"))
+
+    def test_is_path_inline_snps(self):
+        self.assertFalse(_is_path("1,100;2,300"))
+
+    def test_inline_regions(self):
+        # Test regions inline string (e.g., CHR,START,END;CHR,START,END)
+        fp_string = "1,100,200;2,300,400"
+        df = read_to_bed(fp_string)
+        self.assertIsNotNone(df)
+        self.assertListEqual(df["CHR"].tolist(), [1, 2])
+        self.assertListEqual(df["START"].tolist(), [100, 300])
+        self.assertListEqual(df["END"].tolist(), [200, 400])
+
+    def test_inline_snps(self):
+        # Test SNPs inline string (e.g., CHR,POS;CHR,POS)
+        fp_string = "1,100;2,300"
+        df = read_to_bed(fp_string)
+        self.assertIsNotNone(df)
+        self.assertListEqual(df["CHR"].tolist(), [1, 2])
+        self.assertListEqual(df["START"].tolist(), [100, 300])
+        self.assertListEqual(df["END"].tolist(), [101, 301])
 
     def test_bed_format_xy_chromosomes(self):
         # Test X and Y chromosomes


### PR DESCRIPTION
## Description

- Extends `--get-regions-snps` to also accept command-line strings in BED-like (CHR,START,END;CHR,START,END) or SNP-like (CHR,POS;CHR,POS) format.
- Adds related unit test.
- Adds related documentation.

## Issue

Fixes #124