### PR TITLE
Skip region outputs

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -38,6 +38,7 @@ gwasstudio export [OPTIONS]
   - A valid SNP list (CHR,POS) file path or
   - An inline string: "CHR,START,END;CHR,START,END" for regions; "CHR,POS;CHR,POS" for SNPs
 - `--pvalue-filt FLOAT`: Minimum -log10(p-value) threshold to keep significant filtered SNPs (default: 0, no filter)
+- `--skip-out`: Boolean to skip writing region outputs (default: False).
 - `--nest`: Estimate effective population size (Work in progress, not fully implemented yet) (flag).
 
 **Trait-specific Lead-SNP Search Options:**

--- a/scripts/test_01.sh
+++ b/scripts/test_01.sh
@@ -75,6 +75,9 @@ run_command "Regions filtering..." "gwasstudio --stdout --mongo-uri ${MDB_URI} e
 # Regions filtering with P-value threshold
 run_command "Regions filtering with P-value threshold..." "gwasstudio --stdout --mongo-uri ${MDB_URI} export --search-file search_example_01.yml --output-prefix ${TEST_DIR}/example_regions_filtering_pvalue --output-format csv --uri ${TILEDB_DIR} --get-regions-snps regions_query.tsv --pvalue-filt 7.30103"
 
+# Regions filtering with P-value threshold and no output
+run_command "Regions filtering with P-value threshold and skip regions output..." "gwasstudio --stdout --mongo-uri ${MDB_URI} export --search-file search_example_01.yml --output-prefix ${TEST_DIR}/example_regions_filtering_pvalue_skipout --output-format csv --uri ${TILEDB_DIR} --get-regions-snps regions_query.tsv --pvalue-filt 7.30103 --skip-out"
+
 # Regions filtering
 run_command "Regions filtering..." "gwasstudio --stdout --mongo-uri ${MDB_URI} export --search-file search_example_01.yml --output-prefix ${TEST_DIR}/example_regions_filtering_by_arg --output-format csv --uri ${TILEDB_DIR} --get-regions-snps '13,23947562,94021213;15,471752,49338760'"
 

--- a/src/gwasstudio/cli/export.py
+++ b/src/gwasstudio/cli/export.py
@@ -199,7 +199,7 @@ def _process_function_tasks(
             extracted_df = delayed(lambda t: t[0])(extracted_tuple)
             pvalue_filt_df = delayed(lambda t: t[1])(extracted_tuple)
             transformed_df = delayed(_run_transformation)(extracted_df, group, trait, None)
-            result = delayed(write_table)(
+            result = delayed(write_if_not_empty)(
                 transformed_df,
                 output_prefix_dict.get(trait),
                 logger,
@@ -312,6 +312,12 @@ Export summary statistics from TileDB datasets with various filtering options.
         help="Minimum -log10(p-value) threshold to keep significant filtered SNPs",
     ),
     cloup.option(
+        "--skip-out",
+        default=False,
+        is_flag=True,
+        help="Do not write regions output (default: False)",
+    ),
+    cloup.option(
         "--skip-meta",
         default=False,
         is_flag=True,
@@ -415,6 +421,7 @@ def export(
     trans_flanks: int,
     exact_alleles: bool,
     skip_meta: bool,
+    skip_out: bool,
     plot_out: bool,
     color_thr: str,
     s_value: int,
@@ -515,6 +522,7 @@ def export(
                         function_name=extract_regions_snps,
                         regions_snps=bed_fp,
                         pvalue_filt=pvalue_filt,
+                        skip_out=skip_out,
                         plot_out=plot_out,
                         color_thr=color_thr,
                         s_value=s_value,

--- a/src/gwasstudio/methods/extraction_methods.py
+++ b/src/gwasstudio/methods/extraction_methods.py
@@ -87,6 +87,7 @@ def extract_regions_snps(
     tiledb_array: tiledb.Array,
     trait: str,
     output_prefix: str,
+    skip_out: bool,
     plot_out: bool,
     color_thr: str,
     s_value: int,
@@ -104,6 +105,7 @@ def extract_regions_snps(
         regions_snps (pd.DataFrame, optional): A DataFrame containing the genomic regions or SNPs to filter by. Defaults to None.
         pvalue_filt: Minimum -log10(p-value) threshold to keep significant filtered SNPs (default: 0, no filter)
         attributes (list[str], optional): A list of attributes to include in the output. Defaults to None.
+        skip_out (bool, optional): Whether to write regions output. Defaults to False.
         plot_out (bool, optional): Whether to plot the results. Defaults to True.
 
     Returns:
@@ -175,6 +177,9 @@ def extract_regions_snps(
     concatenated_df = process_dataframe(concatenated_df)
     if not snp_filter and pvalue_filt > 0:
         pvalue_filt_df = pd.DataFrame(pvalue_flags)
+        if skip_out:
+            concatenated_df = pd.DataFrame(columns=attributes)
+            logger.warning(f"Skipping regions output for {trait}.")
     else:
         pvalue_filt_df = pd.DataFrame(columns=["CHR", "START", "END", "PVALUE_FILT_FLAG"])
 


### PR DESCRIPTION
## Description

- Adds option `--skip-out` to skip writing region outputs when MLOG10P filtering is active (`--pvalue_filt > 0`) in region extraction (`--get-regions-snps`). Only the tables with region-level p-value filter flags are written.
- Adds related documentation.